### PR TITLE
Use MONGODB_URI environment variable for MongoDB

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -3,8 +3,6 @@ import * as express from 'express';
 import * as mongoose from 'mongoose';
 import * as path from 'path';
 
-const MONGO_URL = `mongodb://cerberus:${process.env.MLAB_PASSWORD}@ds127802.mlab.com:27802/heroku_vhdmcrh0`;
-
 const app = express();
 app.set('port', (process.env.PORT || 3000));
 
@@ -12,7 +10,7 @@ app.use('/', express.static(path.join(__dirname, '../public')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 
-mongoose.connect(MONGO_URL);
+mongoose.connect(process.env.MONGODB_URI);
 const db = mongoose.connection;
 (<any>mongoose).Promise = global.Promise;
 


### PR DESCRIPTION
This will get our app to agree with Heroku's default configurations.

## Testing

1. Add the following to your environment variables:
`MONGODB_URI=mongodb://heroku_vhdmcrh0:mcb2pn0fgtfmbv4thetdjsn2bs@ds127802.mlab.com:27802/heroku_vhdmcrh0`
2. Make sure the app runs.

NOTE: If you get:

    connection error: { MongoError: failed to connect to server [ds127802.mlab.com:27802] on first
    connect [MongoError: getaddrinfo ENOTFOUND ds127802.mlab.com ds127802.mlab.com:27802]

It's probably the proxy.

You can safely remove `MONGODB_URI` after.