### PR TITLE
Fix error on creating organization

### DIFF
--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -37,7 +37,7 @@ describe('AuthService', () => {
   }));
 
   it('should set localStorage items and returns the user', () => {
-    service.setItems(afUser).subscribe(user => {
+    service.setLocalStorage(afUser).subscribe(user => {
       expect(user).toEqual(testUsers[0]);
       expect(localStorage.getItem('user')).toBeTruthy();
       expect(localStorage.getItem('organization')).toBeTruthy();

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -29,13 +29,13 @@ export class AuthService {
   signIn(email: string, password: string): Observable<User> {
     return Observable.fromPromise(this.afAuth.auth
       .signInWithEmailAndPassword(email, password))
-      .switchMap(afUser => this.setItems(afUser))
+      .switchMap(afUser => this.setLocalStorage(afUser))
   }
 
-  setItems(afUser: any): Observable<User> {
+  setLocalStorage(afUser: any): Observable<User> {
     return this.userService.getById(afUser.uid)
-      .switchMap(user => {
-        Object.assign(user, {
+      .switchMap(res => {
+        const user = Object.assign({}, res, {
           id: afUser.uid,
           email: afUser.email
         });

--- a/src/app/services/base.service.ts
+++ b/src/app/services/base.service.ts
@@ -75,18 +75,13 @@ export abstract class BaseService<T> {
    * @returns {Observable<R|T>} - the Observable of the snapshot of the added object
    */
   add(item: T, id?: string): Observable<T> {
-    return id
-      ? Observable.fromPromise(this.collection.doc(id).set(Object.assign({}, this.convertOut(item)))
-        .then(() => this.convertIn(Object.assign({}, item, { id }))))
-        .catch(this.errorService.handleHttpError)
-      : Observable.fromPromise(this.collection.add(Object.assign({}, this.convertOut(item)))
+    return Observable.fromPromise(id
+      ? this.collection.doc(id).set(Object.assign({}, this.convertOut(item)))
+        .then(() => this.convertIn(Object.assign({}, item, { id })))
+      : this.collection.add(Object.assign({}, this.convertOut(item)))
         .then(ref => ref.get()
-          .then(snapshot => {
-            const data = snapshot.data();
-            const snapshotId = snapshot.id;
-            return this.convertIn(Object.assign(data, { snapshotId }))
-          })))
-        .catch(this.errorService.handleHttpError);
+          .then(snapshot => this.convertIn(Object.assign({}, snapshot.data(), { id: snapshot.id })))))
+      .catch(this.errorService.handleHttpError);
   }
 
   /**


### PR DESCRIPTION
Resolves #181.

Fix error when assigning `snapshot.id` to object returned by `BaseService.add()`.