### PR TITLE
Only dispatch an action if the user entered a password and selected s…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -96,8 +96,10 @@ export class AppComponent implements OnInit, OnDestroy {
     dialog.afterClosed()
       .subscribe(
         pwd => {
-          // Once the Observable is returned dispatch an effect
-          this.store.dispatch(new LoginActions.Verify(pwd));
+          if (pwd) {
+            // Once the Observable is returned dispatch an effect
+            this.store.dispatch(new LoginActions.Verify(pwd));
+          }
         }
       );
   }


### PR DESCRIPTION
### Resolves #191

**Purpose**
When the user enters 'Cancel' on the dialog, console errors should not appear.

**Test**

- [x] When selecting cancel there are no console errors and an action is not dispatched.

- [x] When a password is not entered and submit is selected, an action is not dispatched.

- [x] When a password is entered and the user selects submit an action is dispatched. 