### PR TITLE
App sidenav

### DIFF
--- a/src/app/actions/app.actions.ts
+++ b/src/app/actions/app.actions.ts
@@ -1,15 +1,28 @@
 import { Action } from '@ngrx/store';
+import { HeaderOptions } from '../models/header-options';
+import { SidenavOptions } from '../models/sidenav-options';
 
-export const SET_PAGE_CONFIG = '[set_page_config] Set page config';
+export const SET_HEADER_OPTIONS = '[App] Set Header Options';
+export const SET_SIDENAV_OPTIONS = '[App] Set Sidenav Options';
 
 /**
  * Includes side nav options and header options.
  */
-export class SetPageConfig implements Action {
-  readonly type = SET_PAGE_CONFIG;
+export class SetHeaderOptions implements Action {
+  readonly type = SET_HEADER_OPTIONS;
 
-  constructor(public payload: any) {}
+  constructor(public payload: HeaderOptions) {}
+}
+
+/**
+ * Includes side nav options and header options.
+ */
+export class SetSidenavOptions implements Action {
+  readonly type = SET_SIDENAV_OPTIONS;
+
+  constructor(public payload: SidenavOptions[]) {}
 }
 
 export type All
-  = SetPageConfig;
+  = SetHeaderOptions
+  | SetSidenavOptions;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,8 +5,8 @@
               [showLogOut]="isLoggedIn"
               (buttonClick)="onButtonClick($event)">
   </app-header>
-  <div>
+  <app-sidenav>
     <router-outlet></router-outlet>
-  </div>
+  </app-sidenav>
   <app-footer></app-footer>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,7 +6,9 @@
               [showSidenavToggle]="true"
               (buttonClick)="onButtonClick($event)">
   </app-header>
-  <app-sidenav [options]="['User Settings', 'Organization Settings']" (selectIndex)="onSelectIndex($event)">
+  <app-sidenav
+    [options]="['User Settings', 'Organization Settings']"
+    (selectIndex)="onSelectIndex($event)">
     <router-outlet></router-outlet>
   </app-sidenav>
   <app-footer class="hide-xs"></app-footer>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,11 +5,11 @@
     [text]="headerOptions.title"
     [showBack]="!!headerOptions.previousUrl"
     [showLogOut]="isLoggedIn"
-    [showSidenavToggle]="true"
+    [showSidenavToggle]="sidenavOptions.length > 0"
     (buttonClick)="onButtonClick($event)">
   </app-header>
   <app-sidenav
-    [options]="['User Settings', 'Organization Settings']"
+    [options]="sidenavOptions"
     (selectIndex)="onSelectIndex($event)">
     <router-outlet></router-outlet>
   </app-sidenav>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,6 +3,7 @@
               [text]="text"
               [showBack]="!!previousUrl"
               [showLogOut]="isLoggedIn"
+              [showSidenavToggle]="true"
               (buttonClick)="onButtonClick($event)">
   </app-header>
   <app-sidenav>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,7 @@
     [text]="headerOptions.title"
     [showBack]="!!headerOptions.previousUrl"
     [showLogOut]="isLoggedIn"
-    [showSidenavToggle]="sidenavOptions.length > 0"
+    [showSidenavToggle]="!!sidenavOptions"
     (buttonClick)="onButtonClick($event)">
   </app-header>
   <app-sidenav

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,5 +9,5 @@
   <app-sidenav>
     <router-outlet></router-outlet>
   </app-sidenav>
-  <app-footer></app-footer>
+  <app-footer class="hide-xs"></app-footer>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,7 +6,7 @@
               [showSidenavToggle]="true"
               (buttonClick)="onButtonClick($event)">
   </app-header>
-  <app-sidenav>
+  <app-sidenav [options]="['User Settings', 'Organization Settings']" (selectIndex)="onSelectIndex($event)">
     <router-outlet></router-outlet>
   </app-sidenav>
   <app-footer class="hide-xs"></app-footer>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -5,9 +5,9 @@
   height: 100%;
   max-width: 100%;
   display: grid;
-  grid-template-rows: $mat-toolbar-height-desktop auto $mat-toolbar-height-desktop;
+  grid-template-rows: $mat-toolbar-height-desktop 100vh $mat-toolbar-height-desktop;
 
   @media ($mat-xsmall) {
-    grid-template-rows: $mat-toolbar-height-mobile auto $mat-toolbar-height-mobile;
+    grid-template-rows: $mat-toolbar-height-mobile 100vh $mat-toolbar-height-mobile;
   }
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -5,9 +5,9 @@
   height: 100%;
   max-width: 100%;
   display: grid;
-  grid-template-rows: $mat-toolbar-height-desktop 100vh $mat-toolbar-height-desktop;
+  grid-template-rows: $mat-toolbar-height-desktop auto $mat-toolbar-height-desktop;
 
   @media ($mat-xsmall) {
-    grid-template-rows: $mat-toolbar-height-mobile 100vh $mat-toolbar-height-mobile;
+    grid-template-rows: $mat-toolbar-height-mobile auto $mat-toolbar-height-mobile;
   }
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -8,6 +8,6 @@
   grid-template-rows: $mat-toolbar-height-desktop auto $mat-toolbar-height-desktop;
 
   @media ($mat-xsmall) {
-    grid-template-rows: $mat-toolbar-height-mobile auto $mat-toolbar-height-mobile;
+    grid-template-rows: $mat-toolbar-height-mobile auto;
   }
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -18,7 +18,11 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent,
         MockComponent({ selector: 'app-footer' }),
-        MockComponent({ selector: 'app-header', inputs: ['icon', 'text', 'showBack', 'showLogOut'] })
+        MockComponent({
+          selector: 'app-header',
+          inputs: ['icon', 'text', 'showBack', 'showLogOut', 'showSidenavToggle']
+        }),
+        MockComponent({ selector: 'app-sidenav', inputs: ['options'] })
       ]
     }).compileComponents();
   }));

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -77,7 +77,7 @@ export class AppComponent implements OnInit, OnDestroy {
    */
   onButtonClick(action: string): void {
     switch (action) {
-      case 'menu':
+      case 'sidenav_toggle':
         this.sidenav.toggle();
         break;
       case 'back':

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,10 +6,10 @@ import { Subscription } from 'rxjs/Subscription';
 
 import * as LoginActions from './actions/login.actions';
 import * as RouterActions from './actions/router.actions';
+import { SidenavComponent } from './components/sidenav/sidenav.component';
 import { VerificationDialogComponent } from './containers/verification-dialog/verification-dialog.component';
 import { getLocalStorageObjectProperty } from './functions/localStorageObject';
 import { State } from './reducers/index';
-import { SidenavComponent } from './components/sidenav/sidenav.component';
 
 @Component({
   selector: 'app-root',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
@@ -9,6 +9,7 @@ import * as RouterActions from './actions/router.actions';
 import { VerificationDialogComponent } from './containers/verification-dialog/verification-dialog.component';
 import { getLocalStorageObjectProperty } from './functions/localStorageObject';
 import { State } from './reducers/index';
+import { SidenavComponent } from './components/sidenav/sidenav.component';
 
 @Component({
   selector: 'app-root',
@@ -16,6 +17,7 @@ import { State } from './reducers/index';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit, OnDestroy {
+  @ViewChild(SidenavComponent) sidenav: SidenavComponent;
   routerEventsSubscription: Subscription;
   previousUrl: string;
   icon: string;
@@ -75,6 +77,9 @@ export class AppComponent implements OnInit, OnDestroy {
    */
   onButtonClick(action: string): void {
     switch (action) {
+      case 'menu':
+        this.sidenav.toggle();
+        break;
       case 'back':
         this.store.dispatch(new RouterActions.Back());
         break;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,8 +9,8 @@ import { SidenavComponent } from './components/sidenav/sidenav.component';
 import { VerificationDialogComponent } from './containers/verification-dialog/verification-dialog.component';
 import { getLocalStorageObjectProperty } from './functions/localStorageObject';
 import { HeaderOptions } from './models/header-options';
-import { State } from './reducers/index';
 import { SidenavOptions } from './models/sidenav-options';
+import { State } from './reducers/index';
 
 @Component({
   selector: 'app-root',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,6 +37,10 @@ export class AppComponent implements OnInit, OnDestroy {
     }
   }
 
+  onSelectIndex(index: number) {
+    console.log(index);
+  }
+
   /**
    * Watches for router events to update previousUrl and header display.
    * @returns {Subscription} - the subscription to router.events

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { VerificationDialogComponent } from './containers/verification-dialog/ve
 import { getLocalStorageObjectProperty } from './functions/localStorageObject';
 import { HeaderOptions } from './models/header-options';
 import { State } from './reducers/index';
+import { SidenavOptions } from './models/sidenav-options';
 
 @Component({
   selector: 'app-root',
@@ -18,9 +19,9 @@ import { State } from './reducers/index';
 })
 export class AppComponent implements OnInit, OnDestroy {
   @ViewChild(SidenavComponent) sidenav: SidenavComponent;
-  routerEventsSubscription: Subscription;
   appSubscription: Subscription;
   headerOptions: HeaderOptions;
+  sidenavOptions: SidenavOptions[];
 
   constructor(private changeDetectorRef: ChangeDetectorRef,
               private store: Store<State>,
@@ -32,17 +33,24 @@ export class AppComponent implements OnInit, OnDestroy {
       .select('app')
       .subscribe(state => {
         this.headerOptions = state.headerOptions;
+        this.sidenavOptions = state.sidenavOptions;
         /**
          * TODO:
-         * ExpressionChangedAfterItHasBeenCheckedError generates if the following line is
+         * ExpressionChangedAfterItHasBeenCheckedError is thrown if the following line is
          * not present. Find alternate solution.
          */
         this.changeDetectorRef.detectChanges();
       });
   }
 
+  ngOnDestroy() {
+    if (this.appSubscription) {
+      this.appSubscription.unsubscribe();
+    }
+  }
+
   onSelectIndex(index: number) {
-    console.log(index);
+    this.store.dispatch(this.sidenavOptions[index].action);
   }
 
   /**

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { DataDisplayComponent } from './containers/data-display/data-display.com
 import { GettingStartedComponent } from './containers/getting-started/getting-started.component';
 import { LoginComponent } from './containers/login/login.component';
 import { OrganizationDashboardComponent } from './containers/organization-dashboard/organization-dashboard.component';
+import { SettingsPageComponent } from './containers/settings-page/settings-page.component';
 import { VerificationDialogComponent } from './containers/verification-dialog/verification-dialog.component';
 
 import { AboutUsComponent } from './components/about-us/about-us.component';
@@ -41,9 +42,9 @@ import { NewOrganizationFormComponent } from './components/new-organization-form
 import { NewUserFormComponent } from './components/new-user-form/new-user-form.component';
 import { NewVolunteerFormComponent } from './components/new-volunteer-form/new-volunteer-form.component';
 import { OrganizationConfirmComponent } from './components/organization-confirm/organization-confirm.component';
+import { SidenavComponent } from './components/sidenav/sidenav.component';
 import { VisitHistoryTableComponent } from './components/visit-history-table/visit-history-table.component';
 import { VolunteerMenuComponent } from './components/volunteer-menu/volunteer-menu.component';
-import { SettingsPageComponent } from './containers/settings-page/settings-page.component';
 
 import { AuthService } from './services/auth.service';
 import { ErrorService } from './services/error.service';
@@ -61,7 +62,6 @@ import { LoginEffects } from './effects/login.effects';
 import { RouterEffects } from './effects/router.effects';
 import { reducers } from './reducers/index';
 import { VerificationGuard } from './verificationGuard';
-import { SidenavComponent } from './components/sidenav/sidenav.component';
 
 @NgModule({
   declarations: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import {
   MatAutocompleteModule, MatButtonModule, MatCardModule, MatDialogModule, MatIconModule, MatInputModule, MatListModule, MatPaginatorModule,
-  MatRadioModule, MatSnackBarModule, MatTableModule, MatTabsModule, MatToolbarModule
+  MatRadioModule, MatSidenavModule, MatSnackBarModule, MatTableModule, MatTabsModule, MatToolbarModule
 } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -61,6 +61,7 @@ import { LoginEffects } from './effects/login.effects';
 import { RouterEffects } from './effects/router.effects';
 import { reducers } from './reducers/index';
 import { VerificationGuard } from './verificationGuard';
+import { SidenavComponent } from './components/sidenav/sidenav.component';
 
 @NgModule({
   declarations: [
@@ -83,7 +84,8 @@ import { VerificationGuard } from './verificationGuard';
     SignatureFieldComponent,
     VisitHistoryTableComponent,
     VolunteerMenuComponent,
-    VerificationDialogComponent
+    VerificationDialogComponent,
+    SidenavComponent
   ],
   imports: [
     AngularFireAuthModule,
@@ -111,6 +113,7 @@ import { VerificationGuard } from './verificationGuard';
     MatListModule,
     MatPaginatorModule,
     MatRadioModule,
+    MatSidenavModule,
     MatSnackBarModule,
     MatTableModule,
     MatTabsModule,

--- a/src/app/components/daily-hours-chart/daily-hours-chart.component.scss
+++ b/src/app/components/daily-hours-chart/daily-hours-chart.component.scss
@@ -9,11 +9,7 @@
   max-height: calc(99.9vh - #{$mat-toolbars-height-desktop} - #{$mat-tab-bar-height});
   max-width: 100%;
 
-  @media only screen and ($mat-small) {
-    max-height: calc(99.9vh - #{$mat-toolbars-height-desktop} - #{$mat-tab-bar-height} - 84px);
-  }
-
-  @media only screen and ($mat-xsmall) {
-    max-height: calc(99.9vh - #{$mat-toolbars-height-mobile} - #{$mat-tab-bar-height} - 84px);
+  @media ($mat-xsmall) {
+    max-height: inherit;
   }
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -4,14 +4,29 @@
   </button>
   <i class="material-icons title-icon hide-xs">{{icon}}</i>
   <span class="title-text">{{text}}</span>
-  <button mat-icon-button *ngIf="showBack" (click)="onBack()">
-    <i class="material-icons">keyboard_backspace</i>
-  </button>
+  <div *ngIf="showBack">
+    <button mat-button class="hide-xs" (click)="onBack()">
+      <i class="material-icons">keyboard_backspace</i> Back
+    </button>
+    <button mat-icon-button class="show-xs" (click)="onBack()">
+      <i class="material-icons">keyboard_backspace</i>
+    </button>
+  </div>
   <span class="spacer"></span>
-  <button mat-icon-button *ngIf="showLogOut" (click)="onSettings()" mat-button>
-    <i class="material-icons">settings</i>
-  </button>
-  <button mat-icon-button *ngIf="showLogOut" (click)="onLogOut()" mat-button>
-    <i class="material-icons">exit_to_app</i>
-  </button>
+  <div *ngIf="showLogOut">
+    <button mat-button class="hide-xs" (click)="onSettings()">
+      <i class="material-icons">settings</i> Settings
+    </button>
+    <button mat-icon-button class="show-xs" (click)="onSettings()">
+      <i class="material-icons">settings</i>
+    </button>
+  </div>
+  <div *ngIf="showLogOut">
+    <button mat-button class="hide-xs" (click)="onLogOut()">
+      <i class="material-icons">exit_to_app</i> Log Out
+    </button>
+    <button mat-icon-button class="show-xs" (click)="onLogOut()">
+      <i class="material-icons">exit_to_app</i>
+    </button>
+  </div>
 </mat-toolbar>

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,20 +1,17 @@
 <mat-toolbar color="primary">
-  <button mat-icon-button (click)="onMenu()">
+  <button *ngIf="showSidenavToggle" class="show-xs" mat-icon-button (click)="onSidenavToggle()">
     <mat-icon>menu</mat-icon>
   </button>
-  <i class="material-icons title-icon">{{icon}}</i>
+  <i class="material-icons title-icon hide-xs">{{icon}}</i>
   <span class="title-text">{{text}}</span>
-  <button mat-button *ngIf="showBack" (click)="onBack()">
+  <button mat-icon-button *ngIf="showBack" (click)="onBack()">
     <i class="material-icons">keyboard_backspace</i>
-    <span class="button-text">Back</span>
   </button>
   <span class="spacer"></span>
-  <button *ngIf="showLogOut" (click)="onSettings()" mat-button>
+  <button mat-icon-button *ngIf="showLogOut" (click)="onSettings()" mat-button>
     <i class="material-icons">settings</i>
-    <span class="button-text">Settings</span>
   </button>
-  <button *ngIf="showLogOut" (click)="onLogOut()" mat-button>
+  <button mat-icon-button *ngIf="showLogOut" (click)="onLogOut()" mat-button>
     <i class="material-icons">exit_to_app</i>
-    <span class="button-text">Log Out</span>
   </button>
 </mat-toolbar>

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,16 +1,19 @@
 <mat-toolbar color="primary">
+  <button mat-icon-button (click)="onMenu()">
+    <mat-icon>menu</mat-icon>
+  </button>
   <i class="material-icons title-icon">{{icon}}</i>
   <span class="title-text">{{text}}</span>
-  <button mat-button *ngIf="showBack" (click)="back()">
+  <button mat-button *ngIf="showBack" (click)="onBack()">
     <i class="material-icons">keyboard_backspace</i>
     <span class="button-text">Back</span>
   </button>
   <span class="spacer"></span>
-  <button *ngIf="showLogOut" (click)="settings()" mat-button>
+  <button *ngIf="showLogOut" (click)="onSettings()" mat-button>
     <i class="material-icons">settings</i>
     <span class="button-text">Settings</span>
   </button>
-  <button *ngIf="showLogOut" (click)="logOut()" mat-button>
+  <button *ngIf="showLogOut" (click)="onLogOut()" mat-button>
     <i class="material-icons">exit_to_app</i>
     <span class="button-text">Log Out</span>
   </button>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,5 +1,3 @@
-@import '../../../../node_modules/@angular/material/theming';
-
 .title-icon {
   padding-right: 0.5rem;
 }
@@ -11,10 +9,7 @@
 
 .button-text {
   font-weight: lighter;
-
-  @media ($mat-xsmall) {
-    display: none;
-  }
+  font-size: small;
 }
 
 .spacer {

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -7,9 +7,8 @@
   margin-right: 1em;
 }
 
-.button-text {
+.mat-button {
   font-weight: lighter;
-  font-size: small;
 }
 
 .spacer {

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatToolbarModule } from '@angular/material';
+import { MatIconModule, MatToolbarModule } from '@angular/material';
 
 import { HeaderComponent } from './header.component';
 
@@ -10,6 +10,7 @@ describe('HeaderComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
+        MatIconModule,
         MatToolbarModule
       ],
       declarations: [
@@ -28,21 +29,27 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should emit a buttonClick event on clicking sidenavToggle', () => {
+    spyOn(component.buttonClick, 'emit');
+    component.onSidenavToggle();
+    expect(component.buttonClick.emit).toHaveBeenCalledWith('sidenav_toggle');
+  });
+
   it('should emit a buttonClick event on clicking back', () => {
     spyOn(component.buttonClick, 'emit');
-    component.back();
+    component.onBack();
     expect(component.buttonClick.emit).toHaveBeenCalledWith('back');
   });
 
   it('should emit a buttonClick event on clicking settings', () => {
     spyOn(component.buttonClick, 'emit');
-    component.settings();
+    component.onSettings();
     expect(component.buttonClick.emit).toHaveBeenCalledWith('settings');
   });
 
   it('should emit a buttonClick event on clicking log out', () => {
     spyOn(component.buttonClick, 'emit');
-    component.logOut();
+    component.onLogOut();
     expect(component.buttonClick.emit).toHaveBeenCalledWith('logOut');
   });
 });

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -10,10 +10,11 @@ export class HeaderComponent {
   @Input() text: string;
   @Input() showBack: boolean;
   @Input() showLogOut: boolean;
+  @Input() showSidenavToggle: boolean;
   @Output() buttonClick = new EventEmitter<string>();
 
-  onMenu(): void {
-    this.buttonClick.emit('menu');
+  onSidenavToggle(): void {
+    this.buttonClick.emit('sidenav_toggle');
   }
 
   onBack(): void {

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -12,15 +12,19 @@ export class HeaderComponent {
   @Input() showLogOut: boolean;
   @Output() buttonClick = new EventEmitter<string>();
 
-  back(): void {
+  onMenu(): void {
+    this.buttonClick.emit('menu');
+  }
+
+  onBack(): void {
     this.buttonClick.emit('back');
   }
 
-  settings(): void {
+  onSettings(): void {
     this.buttonClick.emit('settings');
   }
 
-  logOut(): void {
+  onLogOut(): void {
     this.buttonClick.emit('logOut');
   }
 }

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -4,7 +4,7 @@
       <mat-list-item
         *ngFor="let option of options; let i = index"
         (click)="onClick(i)">
-        {{option}}
+        {{option.label}}
       </mat-list-item>
     </mat-nav-list>
   </mat-sidenav>

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -1,0 +1,12 @@
+<mat-sidenav-container class="container">
+  <mat-sidenav [mode]="mobileQuery.matches ? 'over' : 'side'">
+    <mat-nav-list>
+      <mat-list-item>Item 1 Longer text</mat-list-item>
+      <mat-list-item>Item 2</mat-list-item>
+      <mat-list-item>Item 3</mat-list-item>
+    </mat-nav-list>
+  </mat-sidenav>
+  <mat-sidenav-content>
+    <ng-content></ng-content>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -1,9 +1,7 @@
 <mat-sidenav-container class="container">
   <mat-sidenav [mode]="mobileQuery.matches ? 'over' : 'side'">
     <mat-nav-list>
-      <mat-list-item>Item 1 Longer text</mat-list-item>
-      <mat-list-item>Item 2</mat-list-item>
-      <mat-list-item>Item 3</mat-list-item>
+      <mat-list-item *ngFor="let option of options; let i = index" (click)="onClick(i)">{{option}}</mat-list-item>
     </mat-nav-list>
   </mat-sidenav>
   <mat-sidenav-content>

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -1,7 +1,11 @@
 <mat-sidenav-container class="container">
-  <mat-sidenav [mode]="mobileQuery.matches ? 'over' : 'side'">
+  <mat-sidenav [mode]="mode">
     <mat-nav-list>
-      <mat-list-item *ngFor="let option of options; let i = index" (click)="onClick(i)">{{option}}</mat-list-item>
+      <mat-list-item
+        *ngFor="let option of options; let i = index"
+        (click)="onClick(i)">
+        {{option}}
+      </mat-list-item>
     </mat-nav-list>
   </mat-sidenav>
   <mat-sidenav-content>

--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -4,6 +4,7 @@
       <mat-list-item
         *ngFor="let option of options; let i = index"
         (click)="onClick(i)">
+        <i class="material-icons" *ngIf="option.icon">{{option.icon}}</i>
         {{option.label}}
       </mat-list-item>
     </mat-nav-list>

--- a/src/app/components/sidenav/sidenav.component.scss
+++ b/src/app/components/sidenav/sidenav.component.scss
@@ -5,3 +5,8 @@
 mat-sidenav {
   box-shadow: 3px 0 6px rgba(0,0,0,.24);
 }
+
+.material-icons {
+  padding-right: 0.5rem;
+  color: mediumaquamarine;
+}

--- a/src/app/components/sidenav/sidenav.component.scss
+++ b/src/app/components/sidenav/sidenav.component.scss
@@ -1,0 +1,7 @@
+.container {
+  height: 100%;
+}
+
+mat-sidenav {
+  box-shadow: 3px 0 6px rgba(0,0,0,.24);
+}

--- a/src/app/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/components/sidenav/sidenav.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SidenavComponent } from './sidenav.component';
+
+describe('SidenavComponent', () => {
+  let component: SidenavComponent;
+  let fixture: ComponentFixture<SidenavComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SidenavComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SidenavComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/components/sidenav/sidenav.component.spec.ts
@@ -1,4 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatListModule, MatSidenavModule } from '@angular/material';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SidenavComponent } from './sidenav.component';
 
@@ -8,9 +11,18 @@ describe('SidenavComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SidenavComponent ]
-    })
-    .compileComponents();
+      declarations: [
+        SidenavComponent
+      ],
+      imports: [
+        MatListModule,
+        MatSidenavModule,
+        NoopAnimationsModule
+      ],
+      providers: [
+        MediaMatcher
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/components/sidenav/sidenav.component.spec.ts
@@ -1,6 +1,6 @@
+import { MediaMatcher } from '@angular/cdk/layout';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatListModule, MatSidenavModule } from '@angular/material';
-import { MediaMatcher } from '@angular/cdk/layout';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SidenavComponent } from './sidenav.component';

--- a/src/app/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/components/sidenav/sidenav.component.spec.ts
@@ -34,4 +34,32 @@ describe('SidenavComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should emit a selectIndex event on click', () => {
+    spyOn(component.selectIndex, 'emit');
+    component.onClick(0);
+    expect(component.selectIndex.emit).toHaveBeenCalledWith(0);
+  });
+
+  it('should set the sidenav for small screens', () => {
+    spyOn(component.sidenav, 'close');
+    component.setForScreen(true);
+    expect(component.mode).toEqual('over');
+    expect(component.sidenav.disableClose).toBeFalsy();
+    expect(component.sidenav.close).toHaveBeenCalled();
+  });
+
+  it('should set the sidenav for large screens', () => {
+    spyOn(component.sidenav, 'open');
+    component.setForScreen(false);
+    expect(component.mode).toEqual('side');
+    expect(component.sidenav.disableClose).toBeTruthy();
+    expect(component.sidenav.open).toHaveBeenCalled();
+  });
+
+  it('should toggle the sidenav', () => {
+    spyOn(component.sidenav, 'toggle');
+    component.toggle();
+    expect(component.sidenav.toggle).toHaveBeenCalled();
+  });
 });

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,5 +1,5 @@
 import { MediaMatcher } from '@angular/cdk/layout';
-import { ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { MatSidenav } from '@angular/material';
 
 @Component({
@@ -9,6 +9,8 @@ import { MatSidenav } from '@angular/material';
 })
 export class SidenavComponent implements OnInit, OnDestroy {
   @ViewChild(MatSidenav) sidenav: MatSidenav;
+  @Input() options: string[];
+  @Output() selectIndex = new EventEmitter<number>();
   mobileQuery: MediaQueryList;
 
   private mobileQueryListener: () => void;
@@ -28,6 +30,10 @@ export class SidenavComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.mobileQuery.removeListener(this.mobileQueryListener);
+  }
+
+  onClick(index: number): void {
+    this.selectIndex.emit(index);
   }
 
   setForScreen(query): void {

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,5 +1,5 @@
 import { MediaMatcher } from '@angular/cdk/layout';
-import { ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { MatSidenav } from '@angular/material';
 
 @Component({
@@ -12,17 +12,17 @@ export class SidenavComponent implements OnInit, OnDestroy {
   @Input() options: string[];
   @Output() selectIndex = new EventEmitter<number>();
   mobileQuery: MediaQueryList;
+  mode: string;
 
   private mobileQueryListener: () => void;
 
   constructor(media: MediaMatcher) {
     this.mobileQuery = media.matchMedia('(max-width: 600px)');
-    this.mobileQueryListener = () => this.setForScreen();
-    this.mobileQuery.addListener(this.mobileQueryListener);
+    this.mobileQuery.addListener(() => this.setForScreen(this.mobileQuery.matches));
   }
 
   ngOnInit(): void {
-    this.setForScreen();
+    this.setForScreen(this.mobileQuery.matches);
   }
 
   ngOnDestroy(): void {
@@ -33,13 +33,15 @@ export class SidenavComponent implements OnInit, OnDestroy {
     this.selectIndex.emit(index);
   }
 
-  setForScreen(): void {
-    if (!this.mobileQuery.matches) {
-      this.sidenav.disableClose = true;
-      this.sidenav.open();
-    } else {
+  setForScreen(xs: boolean): void {
+    if (xs) {
+      this.mode = 'over';
       this.sidenav.disableClose = false;
       this.sidenav.close();
+    } else {
+      this.mode = 'side';
+      this.sidenav.disableClose = true;
+      this.sidenav.open();
     }
   }
 

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,0 +1,46 @@
+import { MediaMatcher } from '@angular/cdk/layout';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { MatSidenav } from '@angular/material';
+
+@Component({
+  selector: 'app-sidenav',
+  templateUrl: './sidenav.component.html',
+  styleUrls: ['./sidenav.component.scss']
+})
+export class SidenavComponent implements OnInit, OnDestroy {
+  @ViewChild(MatSidenav) sidenav: MatSidenav;
+  mobileQuery: MediaQueryList;
+
+  private mobileQueryListener: () => void;
+
+  constructor(changeDetectorRef: ChangeDetectorRef, media: MediaMatcher) {
+    this.mobileQuery = media.matchMedia('(max-width: 600px)');
+    this.mobileQueryListener = query => {
+      changeDetectorRef.detectChanges();
+      this.setForScreen(query);
+    };
+    this.mobileQuery.addListener(this.mobileQueryListener);
+  }
+
+  ngOnInit(): void {
+    this.setForScreen(this.mobileQuery);
+  }
+
+  ngOnDestroy(): void {
+    this.mobileQuery.removeListener(this.mobileQueryListener);
+  }
+
+  setForScreen(query): void {
+    if (!query.matches) {
+      this.sidenav.disableClose = true;
+      this.sidenav.open();
+    } else {
+      this.sidenav.disableClose = false;
+      this.sidenav.close();
+    }
+  }
+
+  toggle(): void {
+    this.sidenav.toggle();
+  }
+}

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -15,17 +15,14 @@ export class SidenavComponent implements OnInit, OnDestroy {
 
   private mobileQueryListener: () => void;
 
-  constructor(changeDetectorRef: ChangeDetectorRef, media: MediaMatcher) {
+  constructor(media: MediaMatcher) {
     this.mobileQuery = media.matchMedia('(max-width: 600px)');
-    this.mobileQueryListener = query => {
-      changeDetectorRef.detectChanges();
-      this.setForScreen(query);
-    };
+    this.mobileQueryListener = () => this.setForScreen();
     this.mobileQuery.addListener(this.mobileQueryListener);
   }
 
   ngOnInit(): void {
-    this.setForScreen(this.mobileQuery);
+    this.setForScreen();
   }
 
   ngOnDestroy(): void {
@@ -36,8 +33,8 @@ export class SidenavComponent implements OnInit, OnDestroy {
     this.selectIndex.emit(index);
   }
 
-  setForScreen(query): void {
-    if (!query.matches) {
+  setForScreen(): void {
+    if (!this.mobileQuery.matches) {
       this.sidenav.disableClose = true;
       this.sidenav.open();
     } else {

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,5 +1,5 @@
 import { MediaMatcher } from '@angular/cdk/layout';
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { MatSidenav } from '@angular/material';
 import { SidenavOptions } from '../../models/sidenav-options';
 
@@ -8,7 +8,7 @@ import { SidenavOptions } from '../../models/sidenav-options';
   templateUrl: './sidenav.component.html',
   styleUrls: ['./sidenav.component.scss']
 })
-export class SidenavComponent implements OnInit, OnDestroy {
+export class SidenavComponent implements OnChanges, OnInit, OnDestroy {
   @ViewChild(MatSidenav) sidenav: MatSidenav;
   @Input() options: SidenavOptions[];
   @Output() selectIndex = new EventEmitter<number>();
@@ -22,8 +22,18 @@ export class SidenavComponent implements OnInit, OnDestroy {
     this.mobileQuery.addListener(() => this.setForScreen(this.mobileQuery.matches));
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['options']) {
+      if (changes['options'].currentValue) {
+        this.setForScreen(this.mobileQuery.matches);
+      } else {
+        this.sidenav.close();
+      }
+      console.log('change!');
+    }
+  }
+
   ngOnInit(): void {
-    this.setForScreen(this.mobileQuery.matches);
   }
 
   ngOnDestroy(): void {

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,6 +1,7 @@
 import { MediaMatcher } from '@angular/cdk/layout';
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { MatSidenav } from '@angular/material';
+import { SidenavOptions } from '../../models/sidenav-options';
 
 @Component({
   selector: 'app-sidenav',
@@ -9,7 +10,7 @@ import { MatSidenav } from '@angular/material';
 })
 export class SidenavComponent implements OnInit, OnDestroy {
   @ViewChild(MatSidenav) sidenav: MatSidenav;
-  @Input() options: string[];
+  @Input() options: SidenavOptions[];
   @Output() selectIndex = new EventEmitter<number>();
   mobileQuery: MediaQueryList;
   mode: string;

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,6 +1,7 @@
 import { MediaMatcher } from '@angular/cdk/layout';
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { MatSidenav } from '@angular/material';
+
 import { SidenavOptions } from '../../models/sidenav-options';
 
 @Component({

--- a/src/app/components/sidenav/sidenav.component.ts
+++ b/src/app/components/sidenav/sidenav.component.ts
@@ -1,5 +1,5 @@
 import { MediaMatcher } from '@angular/cdk/layout';
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { MatSidenav } from '@angular/material';
 
 import { SidenavOptions } from '../../models/sidenav-options';
@@ -9,7 +9,7 @@ import { SidenavOptions } from '../../models/sidenav-options';
   templateUrl: './sidenav.component.html',
   styleUrls: ['./sidenav.component.scss']
 })
-export class SidenavComponent implements OnChanges, OnInit, OnDestroy {
+export class SidenavComponent implements OnChanges, OnDestroy {
   @ViewChild(MatSidenav) sidenav: MatSidenav;
   @Input() options: SidenavOptions[];
   @Output() selectIndex = new EventEmitter<number>();
@@ -23,6 +23,10 @@ export class SidenavComponent implements OnChanges, OnInit, OnDestroy {
     this.mobileQuery.addListener(() => this.setForScreen(this.mobileQuery.matches));
   }
 
+  /**
+   * Sets the sidenav on options changes.
+   * @param changes - contains options changes
+   */
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['options']) {
       if (changes['options'].currentValue) {
@@ -34,17 +38,22 @@ export class SidenavComponent implements OnChanges, OnInit, OnDestroy {
     }
   }
 
-  ngOnInit(): void {
-  }
-
   ngOnDestroy(): void {
     this.mobileQuery.removeListener(this.mobileQueryListener);
   }
 
+  /**
+   * Handles click events from an option by emitting the selectIndex event.
+   * @param index - the selected index.
+   */
   onClick(index: number): void {
     this.selectIndex.emit(index);
   }
 
+  /**
+   * Sets the sidenav for xs screen size or larger.
+   * @param xs - true if xs screen size
+   */
   setForScreen(xs: boolean): void {
     if (xs) {
       this.mode = 'over';
@@ -57,6 +66,9 @@ export class SidenavComponent implements OnChanges, OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Toggles the sidenav.
+   */
   toggle(): void {
     this.sidenav.toggle();
   }

--- a/src/app/containers/check-in/check-in.component.ts
+++ b/src/app/containers/check-in/check-in.component.ts
@@ -7,10 +7,10 @@ import { Subscription } from 'rxjs/Subscription';
 import * as AppActions from '../../actions/app.actions';
 import * as CheckInActions from '../../actions/check-in.actions';
 import { getLocalStorageObjectProperty } from '../../functions/localStorageObject';
+import { HeaderOptions } from '../../models/header-options';
 import { Visit } from '../../models/visit';
 import { Volunteer } from '../../models/volunteer';
 import { State } from '../../reducers/index';
-import { HeaderOptions } from '../../models/header-options';
 
 @Component({
   selector: 'app-check-in',
@@ -29,17 +29,19 @@ export class CheckInComponent implements OnInit, OnDestroy {
               private activatedRoute: ActivatedRoute) { }
 
   ngOnInit(): void {
+    this.store.dispatch(
+      new AppActions.SetHeaderOptions(new HeaderOptions(
+        getLocalStorageObjectProperty('organization', 'name'),
+        'business',
+        '/dashboard'
+      ))
+    );
+    this.store.dispatch(new AppActions.SetSidenavOptions(null));
+
     this.organizationId = getLocalStorageObjectProperty('organization', 'id');
     this.siteId = this.activatedRoute.snapshot.paramMap.get('id');
     this.store.dispatch(
       new CheckInActions.LoadData({ siteId: this.siteId, organizationId: this.organizationId }),
-      );
-    this.store.dispatch(
-      new AppActions.SetHeaderOptions(new HeaderOptions(
-        '/dashboard',
-        'business',
-        getLocalStorageObjectProperty('organization', 'name')
-      ))
     );
     this.checkInSubscription = this.store
       .select('checkIn')

--- a/src/app/containers/check-in/check-in.component.ts
+++ b/src/app/containers/check-in/check-in.component.ts
@@ -10,6 +10,7 @@ import { getLocalStorageObjectProperty } from '../../functions/localStorageObjec
 import { Visit } from '../../models/visit';
 import { Volunteer } from '../../models/volunteer';
 import { State } from '../../reducers/index';
+import { HeaderOptions } from '../../models/header-options';
 
 @Component({
   selector: 'app-check-in',
@@ -34,14 +35,11 @@ export class CheckInComponent implements OnInit, OnDestroy {
       new CheckInActions.LoadData({ siteId: this.siteId, organizationId: this.organizationId }),
       );
     this.store.dispatch(
-      new AppActions.SetPageConfig({
-        sidenavOptions: {},
-        headerOptions: {
-          previousUrl: '/dashboard',
-          icon: 'business',
-          title: getLocalStorageObjectProperty('organization', 'name')
-        }
-      })
+      new AppActions.SetHeaderOptions(new HeaderOptions(
+        '/dashboard',
+        'business',
+        getLocalStorageObjectProperty('organization', 'name')
+      ))
     );
     this.checkInSubscription = this.store
       .select('checkIn')

--- a/src/app/containers/getting-started/getting-started.component.ts
+++ b/src/app/containers/getting-started/getting-started.component.ts
@@ -8,6 +8,7 @@ import * as GettingStartedActions from '../../actions/getting-started.actions';
 import { Organization } from '../../models/organization';
 import { User } from '../../models/user';
 import { State } from '../../reducers/index';
+import { HeaderOptions } from '../../models/header-options';
 
 @Component({
   selector: 'app-getting-started',
@@ -32,16 +33,13 @@ export class GettingStartedComponent implements OnInit, OnDestroy {
         this.validOrganization = state.validOrganization;
         this.validUser = state.validUser;
       });
-    this.store.dispatch(
-      new AppActions.SetPageConfig({
-        sidenavOptions: {},
-        headerOptions: {
-          previousUrl: '/login',
-          icon: 'wb_sunny',
-          title: 'Getting Started'
-        }
-      })
-    );
+    this.store.dispatch(new AppActions.SET_HEADER_OPTIONS(
+      new HeaderOptions(
+        '/login',
+        'wb_sunny',
+        'Getting Started'
+      )
+    ));
   }
 
   ngOnDestroy(): void {

--- a/src/app/containers/getting-started/getting-started.component.ts
+++ b/src/app/containers/getting-started/getting-started.component.ts
@@ -5,10 +5,10 @@ import { Subscription } from 'rxjs/Subscription';
 
 import * as AppActions from '../../actions/app.actions';
 import * as GettingStartedActions from '../../actions/getting-started.actions';
+import { HeaderOptions } from '../../models/header-options';
 import { Organization } from '../../models/organization';
 import { User } from '../../models/user';
 import { State } from '../../reducers/index';
-import { HeaderOptions } from '../../models/header-options';
 
 @Component({
   selector: 'app-getting-started',
@@ -25,6 +25,15 @@ export class GettingStartedComponent implements OnInit, OnDestroy {
   constructor(private store: Store<State>) { }
 
   ngOnInit(): void {
+    this.store.dispatch(new AppActions.SetHeaderOptions(
+      new HeaderOptions(
+        'Getting Started',
+        'wb_sunny',
+        '/login'
+      )
+    ));
+    this.store.dispatch(new AppActions.SetSidenavOptions(null));
+
     this.gettingStartedSubscription = this.store
       .select('gettingStarted')
       .subscribe(state => {
@@ -33,13 +42,6 @@ export class GettingStartedComponent implements OnInit, OnDestroy {
         this.validOrganization = state.validOrganization;
         this.validUser = state.validUser;
       });
-    this.store.dispatch(new AppActions.SET_HEADER_OPTIONS(
-      new HeaderOptions(
-        '/login',
-        'wb_sunny',
-        'Getting Started'
-      )
-    ));
   }
 
   ngOnDestroy(): void {

--- a/src/app/containers/login/login.component.ts
+++ b/src/app/containers/login/login.component.ts
@@ -6,6 +6,7 @@ import { Store } from '@ngrx/store';
 import * as AppActions from '../../actions/app.actions';
 import * as LoginActions from '../../actions/login.actions';
 import { State } from '../../reducers/index';
+import { HeaderOptions } from '../../models/header-options';
 
 @Component({
   selector: 'app-login',
@@ -24,16 +25,13 @@ export class LoginComponent implements OnInit {
   ngOnInit() {
     this.loginForm = this.createForm();
     this.hidePwd = true;
-    this.store.dispatch(
-      new AppActions.SetPageConfig({
-        sidenavOptions: {},
-        headerOptions: {
-          previousUrl: null,
-          icon: 'group_work',
-          title: 'Cerberus'
-        }
-      })
-    );
+    this.store.dispatch(new AppActions.SetHeaderOptions(
+      new HeaderOptions(
+        null,
+        'group_work',
+        'Cerberus'
+      )
+    ));
   }
 
   onLogin() {

--- a/src/app/containers/login/login.component.ts
+++ b/src/app/containers/login/login.component.ts
@@ -7,6 +7,7 @@ import * as AppActions from '../../actions/app.actions';
 import * as LoginActions from '../../actions/login.actions';
 import { State } from '../../reducers/index';
 import { HeaderOptions } from '../../models/header-options';
+import { SidenavOptions } from '../../models/sidenav-options';
 
 @Component({
   selector: 'app-login',
@@ -27,11 +28,12 @@ export class LoginComponent implements OnInit {
     this.hidePwd = true;
     this.store.dispatch(new AppActions.SetHeaderOptions(
       new HeaderOptions(
-        null,
+        'Cerberus',
         'group_work',
-        'Cerberus'
+        null
       )
     ));
+    this.store.dispatch(new AppActions.SetSidenavOptions(null));
   }
 
   onLogin() {

--- a/src/app/containers/login/login.component.ts
+++ b/src/app/containers/login/login.component.ts
@@ -5,9 +5,8 @@ import { Store } from '@ngrx/store';
 
 import * as AppActions from '../../actions/app.actions';
 import * as LoginActions from '../../actions/login.actions';
-import { State } from '../../reducers/index';
 import { HeaderOptions } from '../../models/header-options';
-import { SidenavOptions } from '../../models/sidenav-options';
+import { State } from '../../reducers/index';
 
 @Component({
   selector: 'app-login',

--- a/src/app/containers/organization-dashboard/organization-dashboard.component.html
+++ b/src/app/containers/organization-dashboard/organization-dashboard.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <app-volunteer-menu [sites]="sites$ | async" (siteClick)="onSiteClick($event)">
-  </app-volunteer-menu>
+  <!--<app-volunteer-menu [sites]="sites$ | async" (siteClick)="onSiteClick($event)">-->
+  <!--</app-volunteer-menu>-->
   <app-data-display></app-data-display>
 </div>

--- a/src/app/containers/organization-dashboard/organization-dashboard.component.html
+++ b/src/app/containers/organization-dashboard/organization-dashboard.component.html
@@ -1,5 +1,3 @@
 <div class="container">
-  <!--<app-volunteer-menu [sites]="sites$ | async" (siteClick)="onSiteClick($event)">-->
-  <!--</app-volunteer-menu>-->
   <app-data-display></app-data-display>
 </div>

--- a/src/app/containers/organization-dashboard/organization-dashboard.component.scss
+++ b/src/app/containers/organization-dashboard/organization-dashboard.component.scss
@@ -3,10 +3,5 @@
 .container {
   height: 100%;
   display: grid;
-  grid-template-columns: 17.5% auto;
-
-  @media ($mat-small) {
-    grid-template-columns: auto;
-    grid-template-rows: 84px auto;
-  }
+  grid-template-rows: auto;
 }

--- a/src/app/containers/organization-dashboard/organization-dashboard.component.ts
+++ b/src/app/containers/organization-dashboard/organization-dashboard.component.ts
@@ -25,24 +25,25 @@ export class OrganizationDashboardComponent implements OnInit, OnDestroy {
               private siteService: SiteService) { }
 
   ngOnInit(): void {
+    this.store.dispatch(new AppActions.SetHeaderOptions(
+      new HeaderOptions(
+        getLocalStorageObjectProperty('organization', 'name'),
+        'business',
+        null
+      )
+    ));
     this.sitesSubscription = this.siteService
       .getByKey(
         'organizationId',
         getLocalStorageObjectProperty('organization', 'id'),
         true
       )
-      .subscribe(sites =>
-        this.store.dispatch(new AppActions.SetSidenavOptions(
-          sites.map(site => new SidenavOptions('Check In', site.id))
+      .subscribe(sites => this.store.dispatch(new AppActions.SetSidenavOptions(
+        sites.map(site => new SidenavOptions(
+          'Check In',
+          new RouterActions.Go({ path: [`/checkin/${site.id}`] })
         ))
-      );
-    this.store.dispatch(new AppActions.SetHeaderOptions(
-      new HeaderOptions(
-        null,
-        'business',
-        getLocalStorageObjectProperty('organization', 'name')
-      )
-    ));
+      )));
   }
 
   ngOnDestroy(): void {

--- a/src/app/containers/organization-dashboard/organization-dashboard.component.ts
+++ b/src/app/containers/organization-dashboard/organization-dashboard.component.ts
@@ -40,6 +40,7 @@ export class OrganizationDashboardComponent implements OnInit, OnDestroy {
       .subscribe(sites => this.store.dispatch(new AppActions.SetSidenavOptions(
         sites.map(site => new SidenavOptions(
           'Check In',
+          'check_circle',
           new RouterActions.Go({ path: [`/checkin/${site.id}`] })
         ))
       )));

--- a/src/app/containers/organization-dashboard/organization-dashboard.component.ts
+++ b/src/app/containers/organization-dashboard/organization-dashboard.component.ts
@@ -1,16 +1,15 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 
 import * as AppActions from '../../actions/app.actions';
 import * as RouterActions from '../../actions/router.actions';
 import { getLocalStorageObjectProperty } from '../../functions/localStorageObject';
+import { HeaderOptions } from '../../models/header-options';
+import { SidenavOptions } from '../../models/sidenav-options';
 import { Site } from '../../models/site';
 import { State } from '../../reducers/index';
 import { SiteService } from '../../services/site.service';
-import { Subscription } from 'rxjs/Subscription';
-import { SidenavOptions } from '../../models/sidenav-options';
-import { HeaderOptions } from '../../models/header-options';
 
 @Component({
   selector: 'app-organization-dashboard',

--- a/src/app/containers/settings-page/settings-page.component.spec.ts
+++ b/src/app/containers/settings-page/settings-page.component.spec.ts
@@ -1,5 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { StoreModule } from '@ngrx/store';
 
+import { reducers } from '../../reducers/index';
 import { SettingsPageComponent } from './settings-page.component';
 
 describe('SettingsPageComponent', () => {
@@ -8,7 +10,12 @@ describe('SettingsPageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SettingsPageComponent]
+      declarations: [
+        SettingsPageComponent
+      ],
+      imports: [
+        StoreModule.forRoot(reducers)
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -1,4 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+
+import * as AppActions from '../../actions/app.actions';
+import { State } from '../../reducers/index';
+import { HeaderOptions } from '../../models/header-options';
 
 @Component({
   selector: 'app-settings-page',
@@ -7,10 +12,16 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SettingsPageComponent implements OnInit {
 
-  constructor() { }
+  constructor(private store: Store<State>) { }
 
   ngOnInit() {
+    this.store.dispatch(new AppActions.SetHeaderOptions(
+      new HeaderOptions(
+        'Settings',
+        'settings',
+        '/dashboard'
+      )
+    ));
     this.store.dispatch(new AppActions.SetSidenavOptions(null));
   }
-
 }

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import * as AppActions from '../../actions/app.actions';
-import { State } from '../../reducers/index';
 import { HeaderOptions } from '../../models/header-options';
+import { State } from '../../reducers/index';
 
 @Component({
   selector: 'app-settings-page',

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -10,6 +10,7 @@ export class SettingsPageComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
+    this.store.dispatch(new AppActions.SetSidenavOptions(null));
   }
 
 }

--- a/src/app/models/sidenav-options.ts
+++ b/src/app/models/sidenav-options.ts
@@ -1,0 +1,18 @@
+import { Action } from '@ngrx/store';
+
+export class SidenavOptions {
+  label: string;
+  action: Action;
+
+  constructor(label: string, action: Action) {
+    this.label = label;
+    this.action = action;
+  }
+}
+
+export const testSidenavOptions: SidenavOptions[] = [
+  {
+    label: 'Go',
+    action: null,
+  }
+];

--- a/src/app/models/sidenav-options.ts
+++ b/src/app/models/sidenav-options.ts
@@ -2,10 +2,12 @@ import { Action } from '@ngrx/store';
 
 export class SidenavOptions {
   label: string;
+  icon: string;
   action: Action;
 
-  constructor(label: string, action: Action) {
+  constructor(label: string, icon: string, action: Action) {
     this.label = label;
+    this.icon = icon;
     this.action = action;
   }
 }
@@ -13,6 +15,7 @@ export class SidenavOptions {
 export const testSidenavOptions: SidenavOptions[] = [
   {
     label: 'Go',
-    action: null,
+    icon: 'forward',
+    action: null
   }
 ];

--- a/src/app/reducers/app.reducer.spec.ts
+++ b/src/app/reducers/app.reducer.spec.ts
@@ -1,6 +1,7 @@
 import * as AppActions from '../actions/app.actions';
 import { testHeaderOptions } from '../models/header-options';
 import * as fromApp from './app.reducer';
+import { testSidenavOptions } from '../models/sidenav-options';
 
 describe('appReducer', () => {
   let testState;
@@ -14,15 +15,20 @@ describe('appReducer', () => {
 
   describe('SET_PAGE_CONFIG', () => {
 
-    it('sets page config', () => {
+    it('sets the header options', () => {
       const state = fromApp.reducer(
         fromApp.initialState,
-        new AppActions.SetPageConfig({
-          sidenavOptions: ['a', 'b'],
-          headerOptions: testHeaderOptions[0]
-        }));
-      expect(state.sidenavOptions).toEqual(['a', 'b']);
+        new AppActions.SET_HEADER_OPTIONS(testHeaderOptions[0])
+      );
       expect(state.headerOptions).toEqual(testHeaderOptions[0]);
+    });
+
+    it('sets the sidenav options', () => {
+      const state = fromApp.reducer(
+        fromApp.initialState,
+        new AppActions.SET_SIDENAV_OPTIONS(testSidenavOptions)
+      );
+      expect(state.sidenavOptions).toEqual(testSidenavOptions);
     });
   });
 });

--- a/src/app/reducers/app.reducer.spec.ts
+++ b/src/app/reducers/app.reducer.spec.ts
@@ -1,7 +1,7 @@
 import * as AppActions from '../actions/app.actions';
 import { testHeaderOptions } from '../models/header-options';
-import * as fromApp from './app.reducer';
 import { testSidenavOptions } from '../models/sidenav-options';
+import * as fromApp from './app.reducer';
 
 describe('appReducer', () => {
   let testState;
@@ -13,20 +13,23 @@ describe('appReducer', () => {
     });
   });
 
-  describe('SET_PAGE_CONFIG', () => {
+  describe('SET_HEADER_OPTIONS', () => {
 
     it('sets the header options', () => {
       const state = fromApp.reducer(
         fromApp.initialState,
-        new AppActions.SET_HEADER_OPTIONS(testHeaderOptions[0])
+        new AppActions.SetHeaderOptions(testHeaderOptions[0])
       );
       expect(state.headerOptions).toEqual(testHeaderOptions[0]);
     });
+  });
+
+  describe('SET_SIDENAV_OPTIONS', () => {
 
     it('sets the sidenav options', () => {
       const state = fromApp.reducer(
         fromApp.initialState,
-        new AppActions.SET_SIDENAV_OPTIONS(testSidenavOptions)
+        new AppActions.SetSidenavOptions(testSidenavOptions)
       );
       expect(state.sidenavOptions).toEqual(testSidenavOptions);
     });

--- a/src/app/reducers/app.reducer.ts
+++ b/src/app/reducers/app.reducer.ts
@@ -1,14 +1,15 @@
 import * as AppActions from '../actions/app.actions';
 import { HeaderOptions } from '../models/header-options';
+import { SidenavOptions } from '../models/sidenav-options';
 
 export interface State {
-  sidenavOptions: string[];
   headerOptions: HeaderOptions;
+  sidenavOptions: SidenavOptions[];
 }
 
 export const initialState: State = {
-  sidenavOptions: null,
-  headerOptions: null
+  headerOptions: null,
+  sidenavOptions: null
 };
 
 export type Action = AppActions.All;
@@ -19,8 +20,8 @@ export function reducer(state = initialState, action: Action): State {
 
     case AppActions.SET_PAGE_CONFIG: {
       return Object.assign({}, state, {
-        sidenavOptions: action.payload.sidenavOptions,
-        headerOptions: action.payload.headerOptions
+        headerOptions: action.payload.headerOptions,
+        sidenavOptions: action.payload.sidenavOptions
       });
     }
 

--- a/src/app/reducers/app.reducer.ts
+++ b/src/app/reducers/app.reducer.ts
@@ -1,3 +1,4 @@
+///<reference path="../actions/app.actions.ts"/>
 import * as AppActions from '../actions/app.actions';
 import { HeaderOptions } from '../models/header-options';
 import { SidenavOptions } from '../models/sidenav-options';
@@ -18,10 +19,15 @@ export function reducer(state = initialState, action: Action): State {
 
   switch (action.type) {
 
-    case AppActions.SET_PAGE_CONFIG: {
+    case AppActions.SET_HEADER_OPTIONS: {
       return Object.assign({}, state, {
-        headerOptions: action.payload.headerOptions,
-        sidenavOptions: action.payload.sidenavOptions
+        headerOptions: action.payload,
+      });
+    }
+
+    case AppActions.SET_SIDENAV_OPTIONS: {
+      return Object.assign({}, state, {
+        sidenavOptions: action.payload
       });
     }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,4 @@
+@import '~@angular/material/theming';
 @import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
 
 $mat-paginator-height: 56px;
@@ -48,6 +49,19 @@ input.capitalize {
   display: grid;
   grid-auto-flow: column;
   grid-gap: 0.5rem;
+}
+
+.hide-xs {
+  @media ($mat-xsmall) {
+    display: none !important;
+  }
+}
+
+.show-xs {
+  display: none !important;
+  @media ($mat-xsmall) {
+    display: block !important;
+  }
 }
 
 /deep/ {


### PR DESCRIPTION
### Resolves #187 

Add an app-level sidenav that can be configured by dispatching an action.

![image](https://user-images.githubusercontent.com/2181467/34391309-608c1934-eb0a-11e7-8a17-362eaab61ea7.png)

## Testing

1. Verify that the sidenav only appears on the dashboard and is cleared properly on pages without sidenav options.
2. Verify that the page responds accordingly to screen size. The sidenav should be locked to the side on large screens and able to be opened/closed on xs.