### PR TITLE
Volunteer data table

### DIFF
--- a/src/app/actions/settings.actions.ts
+++ b/src/app/actions/settings.actions.ts
@@ -16,13 +16,13 @@ export class LoadPage implements Action {
   constructor(public payload: string) {}
 }
 
-export class LoadVolunteers implements Action {
+export class LoadVolunteersPage implements Action {
   readonly type = LOAD_VOLUNTEERS_PAGE;
 
   constructor(public payload: string) {}
 }
 
-export class LoadVolunteersSuccess implements Action {
+export class LoadVolunteersPageSuccess implements Action {
   readonly type = LOAD_VOLUNTEERS_PAGE_SUCCESS;
 
   constructor(public payload: Volunteer[]) {}
@@ -42,7 +42,7 @@ export class UpdateOrganization implements Action {
 
 export type All
   = LoadPage
-  | LoadVolunteers
-  | LoadVolunteersSuccess
+  | LoadVolunteersPage
+  | LoadVolunteersPageSuccess
   | UpdateUser
   | UpdateOrganization;

--- a/src/app/actions/settings.actions.ts
+++ b/src/app/actions/settings.actions.ts
@@ -1,10 +1,32 @@
 import { Action } from '@ngrx/store';
 import { Organization } from '../models/organization';
 import { User } from '../models/user';
+import { Volunteer } from '../models/volunteer';
 
-export const UPDATE_USER = '[update user] Update user';
-export const UPDATE_ORGANIZATION = '[update organization] Update organization';
-export const SET_SIDENAV_SELECTION = '[set sidenav selection] Set sidenav selection';
+export const LOAD_PAGE = '[Settings] Load page';
+export const LOAD_VOLUNTEERS_PAGE = '[Settings] Load volunteers page';
+export const LOAD_VOLUNTEERS_PAGE_SUCCESS = '[Settings] Load volunteers page success';
+
+export const UPDATE_USER = '[Settings] Update user';
+export const UPDATE_ORGANIZATION = '[Settings] Update organization';
+
+export class LoadPage implements Action {
+  readonly type = LOAD_PAGE;
+
+  constructor(public payload: string) {}
+}
+
+export class LoadVolunteers implements Action {
+  readonly type = LOAD_VOLUNTEERS_PAGE;
+
+  constructor(public payload: string) {}
+}
+
+export class LoadVolunteersSuccess implements Action {
+  readonly type = LOAD_VOLUNTEERS_PAGE_SUCCESS;
+
+  constructor(public payload: Volunteer[]) {}
+}
 
 export class UpdateUser implements Action {
   readonly type = UPDATE_USER;
@@ -18,13 +40,9 @@ export class UpdateOrganization implements Action {
   constructor(public payload: Organization) {}
 }
 
-export class SetSidenavSelection implements Action {
-  readonly type = SET_SIDENAV_SELECTION;
-
-  constructor(public payload: string) {}
-}
-
 export type All
-  = UpdateUser
-  | UpdateOrganization
-  | SetSidenavSelection;
+  = LoadPage
+  | LoadVolunteers
+  | LoadVolunteersSuccess
+  | UpdateUser
+  | UpdateOrganization;

--- a/src/app/actions/settings.actions.ts
+++ b/src/app/actions/settings.actions.ts
@@ -3,12 +3,25 @@ import { Organization } from '../models/organization';
 import { User } from '../models/user';
 import { Volunteer } from '../models/volunteer';
 
+export const DELETE_VOLUNTEER = '[Settings] Delete volunteer';
+export const DELETE_VOLUNTEER_SUCCESS = '[Settings] Delete volunteer success';
 export const LOAD_PAGE = '[Settings] Load page';
 export const LOAD_VOLUNTEERS_PAGE = '[Settings] Load volunteers page';
 export const LOAD_VOLUNTEERS_PAGE_SUCCESS = '[Settings] Load volunteers page success';
-
 export const UPDATE_USER = '[Settings] Update user';
 export const UPDATE_ORGANIZATION = '[Settings] Update organization';
+
+export class DeleteVolunteer implements Action {
+  readonly type = DELETE_VOLUNTEER;
+
+  constructor(public payload: Volunteer) {}
+}
+
+export class DeleteVolunteerSuccess implements Action {
+  readonly type = DELETE_VOLUNTEER_SUCCESS;
+
+  constructor(public payload: Volunteer) {}
+}
 
 export class LoadPage implements Action {
   readonly type = LOAD_PAGE;
@@ -41,7 +54,9 @@ export class UpdateOrganization implements Action {
 }
 
 export type All
-  = LoadPage
+  = DeleteVolunteer
+  | DeleteVolunteerSuccess
+  | LoadPage
   | LoadVolunteersPage
   | LoadVolunteersPageSuccess
   | UpdateUser

--- a/src/app/components/data-table/data-table.component.html
+++ b/src/app/components/data-table/data-table.component.html
@@ -4,6 +4,14 @@
       <mat-header-cell *cdkHeaderCellDef>{{column.header}}</mat-header-cell>
       <mat-cell *cdkCellDef="let row">{{column.cell(row)}}</mat-cell>
     </ng-container>
+    <ng-container *ngIf="showDelete" cdkColumnDef="delete">
+      <mat-header-cell *cdkHeaderCellDef>Delete</mat-header-cell>
+      <mat-cell *cdkCellDef="let row">
+        <button mat-icon-button color="warn">
+          <mat-icon aria-label="Delete this entry">delete_forever</mat-icon>
+        </button>
+      </mat-cell>
+    </ng-container>
     <mat-header-row *cdkHeaderRowDef="displayedColumns"></mat-header-row>
     <mat-row *cdkRowDef="let row; columns: displayedColumns;"></mat-row>
   </mat-table>

--- a/src/app/components/data-table/data-table.component.html
+++ b/src/app/components/data-table/data-table.component.html
@@ -7,7 +7,7 @@
     <ng-container *ngIf="showDelete" cdkColumnDef="delete">
       <mat-header-cell *cdkHeaderCellDef>Delete</mat-header-cell>
       <mat-cell *cdkCellDef="let row">
-        <button mat-icon-button color="warn">
+        <button mat-icon-button color="warn" (click)="onClickDelete(row)">
           <mat-icon aria-label="Delete this entry">delete_forever</mat-icon>
         </button>
       </mat-cell>

--- a/src/app/components/data-table/data-table.component.scss
+++ b/src/app/components/data-table/data-table.component.scss
@@ -7,4 +7,8 @@
   overflow-y: auto;
   display: grid;
   grid-template-rows: auto $mat-paginator-height;
+
+  .cdk-column-delete {
+    max-width: 2.5rem;
+  }
 }

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -1,6 +1,6 @@
 import { CdkTableModule } from '@angular/cdk/table';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatListModule, MatPaginatorModule, MatTableModule } from '@angular/material';
+import { MatIconModule, MatListModule, MatPaginatorModule, MatTableModule } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Observable } from 'rxjs/Observable';
 
@@ -19,6 +19,7 @@ describe('DataTableComponent', () => {
       ],
       imports: [
         CdkTableModule,
+        MatIconModule,
         MatListModule,
         MatPaginatorModule,
         MatTableModule,

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { testColumnOptions } from '../../models/column-options';
 import { testVisits } from '../../models/visit';
 import { DataTableComponent, DataTableSource } from './data-table.component';
+import { testVolunteers } from '../../models/volunteer';
 
 describe('DataTableComponent', () => {
   let component: DataTableComponent;
@@ -46,5 +47,12 @@ describe('DataTableComponent', () => {
     component.paginator.pageSize = 2;
     const pageData = component.dataSource.getPageData();
     expect(pageData.length).toEqual(2);
+  });
+
+  it('should emit a clickDelete event on clicking the delete button', () => {
+    spyOn(component.deleteItem, 'emit');
+    const item = testVolunteers[0];
+    component.onClickDelete(item);
+    expect(component.deleteItem.emit).toHaveBeenCalledWith(item);
   });
 });

--- a/src/app/components/data-table/data-table.component.spec.ts
+++ b/src/app/components/data-table/data-table.component.spec.ts
@@ -6,8 +6,8 @@ import { Observable } from 'rxjs/Observable';
 
 import { testColumnOptions } from '../../models/column-options';
 import { testVisits } from '../../models/visit';
-import { DataTableComponent, DataTableSource } from './data-table.component';
 import { testVolunteers } from '../../models/volunteer';
+import { DataTableComponent, DataTableSource } from './data-table.component';
 
 describe('DataTableComponent', () => {
   let component: DataTableComponent;

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -46,7 +46,7 @@ export class DataTableSource extends DataSource<any> implements OnDestroy {
 }
 
 @Component({
-  selector: 'app-visit-history-table',
+  selector: 'app-data-table',
   templateUrl: './data-table.component.html',
   styleUrls: ['./data-table.component.scss']
 })

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -53,6 +53,7 @@ export class DataTableSource extends DataSource<any> implements OnDestroy {
 export class DataTableComponent implements OnInit {
   @Input() data$: Observable<any[]>;
   @Input() columnOptions: ColumnOptions[];
+  @Input() showDelete: boolean;
   displayedColumns: string[];
   initialPageSize: number;
   dataSource: DataTableSource;
@@ -66,5 +67,8 @@ export class DataTableComponent implements OnInit {
     this.initialPageSize = Math.floor((window.innerHeight - surroundingElementsPx) / cellPx);
     this.dataSource = new DataTableSource(this.data$, this.paginator);
     this.displayedColumns = this.columnOptions.map(column => column.columnDef);
+    if (this.showDelete) {
+      this.displayedColumns.push('delete');
+    }
   }
 }

--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -1,5 +1,5 @@
 import { DataSource } from '@angular/cdk/table';
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material';
 import 'rxjs/add/observable/merge';
 import { Observable } from 'rxjs/Observable';
@@ -54,6 +54,7 @@ export class DataTableComponent implements OnInit {
   @Input() data$: Observable<any[]>;
   @Input() columnOptions: ColumnOptions[];
   @Input() showDelete: boolean;
+  @Output() deleteItem = new EventEmitter<any>();
   displayedColumns: string[];
   initialPageSize: number;
   dataSource: DataTableSource;
@@ -70,5 +71,13 @@ export class DataTableComponent implements OnInit {
     if (this.showDelete) {
       this.displayedColumns.push('delete');
     }
+  }
+
+  /**
+   * Handles delete button click events by emitting a deleteItem event.
+   * @param item - the item to be deleted
+   */
+  onClickDelete(item: any): void {
+    this.deleteItem.emit(item);
   }
 }

--- a/src/app/containers/data-display/data-display.component.html
+++ b/src/app/containers/data-display/data-display.component.html
@@ -3,10 +3,10 @@
     <app-daily-hours-chart [visits]="visits$ | async"></app-daily-hours-chart>
   </mat-tab>
   <mat-tab label="Visit History">
-    <app-visit-history-table
+    <app-data-table
       [columnOptions]="visitTableColumnOptions"
       [data$]="visits$"
       [showDelete]="true">
-    </app-visit-history-table>
+    </app-data-table>
   </mat-tab>
 </mat-tab-group>

--- a/src/app/containers/data-display/data-display.component.html
+++ b/src/app/containers/data-display/data-display.component.html
@@ -3,6 +3,10 @@
     <app-daily-hours-chart [visits]="visits$ | async"></app-daily-hours-chart>
   </mat-tab>
   <mat-tab label="Visit History">
-    <app-visit-history-table [columnOptions]="visitTableColumnOptions" [data$]="visits$"></app-visit-history-table>
+    <app-visit-history-table
+      [columnOptions]="visitTableColumnOptions"
+      [data$]="visits$"
+      [showDelete]="true">
+    </app-visit-history-table>
   </mat-tab>
 </mat-tab-group>

--- a/src/app/containers/data-display/data-display.component.spec.ts
+++ b/src/app/containers/data-display/data-display.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatTabsModule } from '@angular/material';
+import { MatIconModule, MatTabsModule } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng2-mock-component';
@@ -16,10 +16,11 @@ describe('DataDisplayComponent', () => {
       declarations: [
         DataDisplayComponent,
         MockComponent({ selector: 'app-daily-hours-chart', inputs: ['visits'] }),
-        MockComponent({ selector: 'app-data-table', inputs: ['columnOptions', 'data$'] })
+        MockComponent({ selector: 'app-data-table', inputs: ['columnOptions', 'data$', 'showDelete'] })
       ],
       imports: [
         NoopAnimationsModule,
+        MatIconModule,
         MatTabsModule,
         StoreModule.forRoot(reducers)
       ]

--- a/src/app/containers/data-display/data-display.component.spec.ts
+++ b/src/app/containers/data-display/data-display.component.spec.ts
@@ -16,7 +16,7 @@ describe('DataDisplayComponent', () => {
       declarations: [
         DataDisplayComponent,
         MockComponent({ selector: 'app-daily-hours-chart', inputs: ['visits'] }),
-        MockComponent({ selector: 'app-visit-history-table', inputs: ['columnOptions', 'data$'] })
+        MockComponent({ selector: 'app-data-table', inputs: ['columnOptions', 'data$'] })
       ],
       imports: [
         NoopAnimationsModule,

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -3,11 +3,11 @@
   <app-user-form
     [title]="userFormTitle"
     [initialUser]="initialUser"
-    (validUser)="setUser($event)"
+    (validUser)="onSetUser($event)"
     [passwordRequired]="false">
   </app-user-form>
   <div class="container-button">
-    <button mat-raised-button color="primary" (click)="onUserFormSubmit()" [disabled]="!validUser">Submit</button>
+    <button mat-raised-button color="primary" (click)="onSubmitUser()" [disabled]="!validUser">Submit</button>
   </div>
 </div>
 <!--Organization form-->
@@ -15,10 +15,10 @@
   <app-organization-form
     [title]="organizationFormTitle"
     [initialOrganization]="initialOrganization"
-    (validOrganization)="setOrganization($event)">
+    (validOrganization)="onValidOrganization($event)">
   </app-organization-form>
   <div class="container-button">
-    <button mat-raised-button color="primary" (click)="onOrganizationFormSubmit()" [disabled]="!validOrganization">
+    <button mat-raised-button color="primary" (click)="onSubmitOrganization()" [disabled]="!validOrganization">
       Submit
     </button>
   </div>

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -10,7 +10,7 @@
     <button
       mat-raised-button
       color="primary"
-      (click)="onSubmitUser(validUser)"
+      (click)="onSubmitUser(validUser, initialUser.id)"
       [disabled]="!validUser">
       Submit
     </button>
@@ -27,18 +27,12 @@
     <button
       mat-raised-button
       color="primary"
-      (click)="onSubmitOrganization()"
+      (click)="onSubmitOrganization(validOrganization, initialOrganization.id)"
       [disabled]="!validOrganization">
       Submit
     </button>
   </div>
 </div>
-<div *ngIf="sidenavSelection == 'Reports'">
-  <app-reports-form
-    (validReport)="setReport($event)">
-  </app-reports-form>
-  <div class="container-button">
-    <button mat-raised-button color="primary" [disabled]="!validReport" (click)="onReportSubmit()">Generate Report</button>
 <!--Volunteer data table-->
 <div *ngIf="sidenavSelection === 'volunteers'">
   <app-data-table
@@ -47,12 +41,12 @@
     [showDelete]="true"
     (deleteItem)="onDeleteVolunteer($event)">
   </app-data-table>
-  <div *ngIf="sidenavSelection == 'Reports'">
-    <app-reports-form
-      (validReport)="setReport($event)">
-    </app-reports-form>
-    <div class="container-button">
-      <button mat-raised-button color="primary" [disabled]="!validReport">Generate Report</button>
-    </div>
+</div>
+<div *ngIf="sidenavSelection == 'Reports'">
+  <app-reports-form
+    (validReport)="setReport($event)">
+  </app-reports-form>
+  <div class="container-button">
+    <button mat-raised-button color="primary" [disabled]="!validReport" (click)="onReportSubmit()">Generate Report</button>
   </div>
 </div>

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -3,7 +3,7 @@
   <app-user-form
     [title]="userFormTitle"
     [initialUser]="initialUser"
-    (validUser)="onSetUser($event)"
+    (validUser)="onValidUser($event)"
     [passwordRequired]="false">
   </app-user-form>
   <div class="container-button">

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -7,7 +7,13 @@
     [passwordRequired]="false">
   </app-user-form>
   <div class="container-button">
-    <button mat-raised-button color="primary" (click)="onSubmitUser()" [disabled]="!validUser">Submit</button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="onSubmitUser(validUser)"
+      [disabled]="!validUser">
+      Submit
+    </button>
   </div>
 </div>
 <!--Organization form-->
@@ -18,7 +24,11 @@
     (validOrganization)="onValidOrganization($event)">
   </app-organization-form>
   <div class="container-button">
-    <button mat-raised-button color="primary" (click)="onSubmitOrganization()" [disabled]="!validOrganization">
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="onSubmitOrganization()"
+      [disabled]="!validOrganization">
       Submit
     </button>
   </div>
@@ -31,11 +41,11 @@
     [showDelete]="true"
     (deleteItem)="onDeleteVolunteer($event)">
   </app-data-table>
-<div *ngIf="sidenavSelection == 'Reports'">
-  <app-reports-form
-    (validReport)="setReport($event)">
-  </app-reports-form>
-  <div class="container-button">
-    <button mat-raised-button color="primary" [disabled]="!validReport">Generate Report</button>
+  <div *ngIf="sidenavSelection == 'Reports'">
+    <app-reports-form
+      (validReport)="setReport($event)">
+    </app-reports-form>
+    <div class="container-button">
+      <button mat-raised-button color="primary" [disabled]="!validReport">Generate Report</button>
+    </div>
   </div>
-</div>

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -28,7 +28,8 @@
   <app-data-table
     [data$]="volunteers$"
     [columnOptions]="volunteerTableOptions"
-  [showDelete]="true">
+    [showDelete]="true"
+    (deleteItem)="onDeleteVolunteer($event)">
   </app-data-table>
 <div *ngIf="sidenavSelection == 'Reports'">
   <app-reports-form

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -1,5 +1,5 @@
-<!--user form-->
-<div *ngIf="sidenavSelection == 'User'">
+<!--User form-->
+<div *ngIf="sidenavSelection === 'User'">
   <app-user-form
     [title]="userFormTitle"
     [initialUser]="initialUser"
@@ -10,8 +10,8 @@
     <button mat-raised-button color="primary" (click)="onUserFormSubmit()" [disabled]="!validUser">Submit</button>
   </div>
 </div>
-<!--organization form-->
-<div *ngIf="sidenavSelection == 'Organization'">
+<!--Organization form-->
+<div *ngIf="sidenavSelection === 'Organization'">
   <app-organization-form
     [title]="organizationFormTitle"
     [initialOrganization]="initialOrganization"
@@ -21,6 +21,11 @@
     <button mat-raised-button color="primary" (click)="onOrganizationFormSubmit()" [disabled]="!validOrganization">Submit</button>
   </div>
 </div>
+<!--Volunteer data table-->
+<div *ngIf="sidenavSelection === 'Volunteer'">
+  <app-data-table
+  >
+  </app-data-table>
 <div *ngIf="sidenavSelection == 'Reports'">
   <app-reports-form
     (validReport)="setReport($event)">

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -11,7 +11,7 @@
   </div>
 </div>
 <!--Organization form-->
-<div *ngIf="sidenavSelection === 'Organization'">
+<div *ngIf="sidenavSelection === 'organization'">
   <app-organization-form
     [title]="organizationFormTitle"
     [initialOrganization]="initialOrganization"
@@ -22,8 +22,9 @@
   </div>
 </div>
 <!--Volunteer data table-->
-<div *ngIf="sidenavSelection === 'Volunteer'">
+<div *ngIf="sidenavSelection === 'volunteer'">
   <app-data-table
+
   >
   </app-data-table>
 <div *ngIf="sidenavSelection == 'Reports'">

--- a/src/app/containers/settings-page/settings-page.component.html
+++ b/src/app/containers/settings-page/settings-page.component.html
@@ -1,5 +1,5 @@
 <!--User form-->
-<div *ngIf="sidenavSelection === 'User'">
+<div *ngIf="sidenavSelection === 'user'">
   <app-user-form
     [title]="userFormTitle"
     [initialUser]="initialUser"
@@ -18,14 +18,17 @@
     (validOrganization)="setOrganization($event)">
   </app-organization-form>
   <div class="container-button">
-    <button mat-raised-button color="primary" (click)="onOrganizationFormSubmit()" [disabled]="!validOrganization">Submit</button>
+    <button mat-raised-button color="primary" (click)="onOrganizationFormSubmit()" [disabled]="!validOrganization">
+      Submit
+    </button>
   </div>
 </div>
 <!--Volunteer data table-->
-<div *ngIf="sidenavSelection === 'volunteer'">
+<div *ngIf="sidenavSelection === 'volunteers'">
   <app-data-table
-
-  >
+    [data$]="volunteers$"
+    [columnOptions]="volunteerTableOptions"
+  [showDelete]="true">
   </app-data-table>
 <div *ngIf="sidenavSelection == 'Reports'">
   <app-reports-form

--- a/src/app/containers/settings-page/settings-page.component.spec.ts
+++ b/src/app/containers/settings-page/settings-page.component.spec.ts
@@ -27,7 +27,7 @@ describe('SettingsPageComponent', () => {
         StoreModule.forRoot(reducers)
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -53,17 +53,21 @@ describe('SettingsPageComponent', () => {
   it('should handle submitUser events by dispatching SettingsActions.UpdateUser', () => {
     spyOn(component.store, 'dispatch');
     const user = testUsers[0];
-    component.onSubmitUser(user);
+    const id = 'testId';
+    const expected = Object.assign({}, user, { id });
+    component.onSubmitUser(user, id);
     expect(component.store.dispatch)
-      .toHaveBeenCalledWith(new SettingsActions.UpdateUser(user));
+      .toHaveBeenCalledWith(new SettingsActions.UpdateUser(expected));
   });
 
   it('should handle updateOrganization events by dispatching SettingsActions.UpdateOrganization', () => {
     spyOn(component.store, 'dispatch');
     const organization = testOrganizations[0];
-    component.onSubmitOrganization(organization);
+    const id = 'testId';
+    const expected = Object.assign({}, organization, { id });
+    component.onSubmitOrganization(organization, id);
     expect(component.store.dispatch)
-      .toHaveBeenCalledWith(new SettingsActions.UpdateOrganization(organization));
+      .toHaveBeenCalledWith(new SettingsActions.UpdateOrganization(expected));
   });
 
   it('should handle deleteVolunteer events by dispatching SettingsActions.DeleteVolunteer', () => {

--- a/src/app/containers/settings-page/settings-page.component.spec.ts
+++ b/src/app/containers/settings-page/settings-page.component.spec.ts
@@ -50,6 +50,22 @@ describe('SettingsPageComponent', () => {
     expect(component.validOrganization).toBe(testOrganizations[0]);
   });
 
+  it('should handle submitUser events by dispatching SettingsActions.UpdateUser', () => {
+    spyOn(component.store, 'dispatch');
+    const user = testUsers[0];
+    component.onSubmitUser(user);
+    expect(component.store.dispatch)
+      .toHaveBeenCalledWith(new SettingsActions.UpdateUser(user));
+  });
+
+  it('should handle updateOrganization events by dispatching SettingsActions.UpdateOrganization', () => {
+    spyOn(component.store, 'dispatch');
+    const organization = testOrganizations[0];
+    component.onSubmitOrganization(organization);
+    expect(component.store.dispatch)
+      .toHaveBeenCalledWith(new SettingsActions.UpdateOrganization(organization));
+  });
+
   it('should handle deleteVolunteer events by dispatching SettingsActions.DeleteVolunteer', () => {
     spyOn(component.store, 'dispatch');
     const volunteer = testVolunteers[0];

--- a/src/app/containers/settings-page/settings-page.component.spec.ts
+++ b/src/app/containers/settings-page/settings-page.component.spec.ts
@@ -7,6 +7,7 @@ import { testReports } from '../../models/report';
 import { testUsers } from '../../models/user';
 import { reducers } from '../../reducers';
 import { SettingsPageComponent } from './settings-page.component';
+import { testVolunteers } from '../../models/volunteer';
 
 describe('SettingsPageComponent', () => {
   let component: SettingsPageComponent;
@@ -37,14 +38,22 @@ describe('SettingsPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set user', () => {
+  it('should handle validUser events by setting validUser', () => {
     component.setUser(testUsers[0]);
     expect(component.validUser).toBe(testUsers[0]);
   });
 
-  it('should set organization', () => {
+  it('should handle validOrganization events by setting validOrganization', () => {
     component.setOrganization(testOrganizations[0]);
     expect(component.validOrganization).toBe(testOrganizations[0]);
+  });
+
+  it('should handle deleteVolunteer events by dispatching SettingsActions.DeleteVolunteer', () => {
+    spyOn(component.store, 'dispatch');
+    const volunteer = testVolunteers[0];
+    component.onDeleteVolunteer(volunteer);
+    expect(component.store.dispatch)
+      .toHaveBeenCalledWith(new SettingsActions.DeleteVolunteer(volunteer));
   });
 
   it('should set report', () => {

--- a/src/app/containers/settings-page/settings-page.component.spec.ts
+++ b/src/app/containers/settings-page/settings-page.component.spec.ts
@@ -1,13 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
-
 import { MockComponent } from 'ng2-mock-component';
+
+import * as SettingsActions from '../../actions/settings.actions';
 import { testOrganizations } from '../../models/organization';
 import { testReports } from '../../models/report';
 import { testUsers } from '../../models/user';
+import { testVolunteers } from '../../models/volunteer';
 import { reducers } from '../../reducers';
 import { SettingsPageComponent } from './settings-page.component';
-import { testVolunteers } from '../../models/volunteer';
 
 describe('SettingsPageComponent', () => {
   let component: SettingsPageComponent;
@@ -17,9 +18,10 @@ describe('SettingsPageComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         SettingsPageComponent,
-        MockComponent({ selector: 'app-user-form', inputs: ['initialUser', 'passwordRequired'] }),
+        MockComponent({ selector: 'app-data-table', inputs: ['columnOptions', 'data$', 'showDelete'] }),
         MockComponent({ selector: 'app-organization-form', inputs: ['initialOrganization'] }),
         MockComponent({ selector: 'app-reports-form' }),
+        MockComponent({ selector: 'app-user-form', inputs: ['initialUser', 'passwordRequired'] }),
       ],
       imports: [
         StoreModule.forRoot(reducers)
@@ -39,12 +41,12 @@ describe('SettingsPageComponent', () => {
   });
 
   it('should handle validUser events by setting validUser', () => {
-    component.setUser(testUsers[0]);
+    component.onValidUser(testUsers[0]);
     expect(component.validUser).toBe(testUsers[0]);
   });
 
   it('should handle validOrganization events by setting validOrganization', () => {
-    component.setOrganization(testOrganizations[0]);
+    component.onValidOrganization(testOrganizations[0]);
     expect(component.validOrganization).toBe(testOrganizations[0]);
   });
 

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -115,42 +115,45 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Once the user-form emits an event,
-   * set user.
-   * @param $event
+   * Handles setUser events by setting validUser..
+   * @param user - a valid user when valid, null when invalid
    */
-  setUser($event) {
-    this.validUser = $event;
+  onSetUser(user: User) {
+    this.validUser = user;
   }
 
   /**
-   * Once the organization-form emits an event,
-   * set organization.
-   * @param $event
+   * Handles setOrganization events by setting validOrganization.
+   * @param organization - a valid organization when valid, null when invalid
    */
-  setOrganization($event) {
-    this.validOrganization = $event;
+  onValidOrganization(organization: Organization) {
+    this.validOrganization = organization;
   }
 
   /**
-   * Once the report-form emits an event,
-   * set report.
-   * @param $event
+   * Handles submission of user form by dispatching an UpdateUser action.
    */
+  onSubmitUser() {
+    this.store.dispatch(new SettingsActions.UpdateUser(this.validUser));
+  }
+
+  /**
+   * Handles submission of organization form by dispatching an UpdateOrganization action.
+   */
+  onSubmitOrganization() {
+    this.store.dispatch(new SettingsActions.UpdateOrganization(this.validOrganization));
+  }
+
+  /**
+   * Handles deleteVolunteer events by dispatching a DeleteVolunteer action.
+   * @param volunteer - the volunteer to be deleted
+   */
+  onDeleteVolunteer(volunteer: Volunteer) {
+    console.log('Delete');
+  }
+
   setReport($event) {
     this.validReport = $event;
-  }
-
-  onUserFormSubmit() {
-    this.store.dispatch(new SettingsActions.UpdateUser(
-      Object.assign({}, this.validUser, { id: this.initialUser.id })
-    ));
-  }
-
-  onOrganizationFormSubmit() {
-    this.store.dispatch(new SettingsActions.UpdateOrganization(
-      Object.assign({}, this.validOrganization, { id: this.initialOrganization.id })
-    ));
   }
 
   ngOnDestroy(): void {

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -39,6 +39,7 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    const organizationId = getLocalStorageObjectProperty('organization', 'id');
     this.store.dispatch(new AppActions.SetHeaderOptions(
       new HeaderOptions(
         'Settings',
@@ -48,8 +49,9 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
       )
     ));
     this.store.dispatch(new AppActions.SetSidenavOptions([
-      new SidenavOptions('User', 'face', new SettingsActions.LoadPage('User')),
-      new SidenavOptions('Organization', 'domain', new SettingsActions.LoadPage('Organization')),
+      new SidenavOptions('User', 'face', new SettingsActions.LoadPage('user')),
+      new SidenavOptions('Organization', 'domain', new SettingsActions.LoadPage('organization')),
+      new SidenavOptions('Volunteers', 'insert_emoticon', new SettingsActions.LoadVolunteersPage(organizationId)),
       new SidenavOptions('Reports', 'assessment', new SettingsActions.LoadPage('Reports'))
     ]));
     this.settingsSubscription = this.store

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -149,7 +149,7 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
    * @param volunteer - the volunteer to be deleted
    */
   onDeleteVolunteer(volunteer: Volunteer) {
-    console.log('Delete');
+    console.log('onDeleteVolunteer', volunteer);
   }
 
   setReport($event) {

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -48,9 +48,9 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
       )
     ));
     this.store.dispatch(new AppActions.SetSidenavOptions([
-      new SidenavOptions('User', 'face', new SettingsActions.SetSidenavSelection('User')),
-      new SidenavOptions('Organization', 'domain', new SettingsActions.SetSidenavSelection('Organization')),
-      new SidenavOptions('Reports', 'assessment', new SettingsActions.SetSidenavSelection('Reports'))
+      new SidenavOptions('User', 'face', new SettingsActions.LoadPage('User')),
+      new SidenavOptions('Organization', 'domain', new SettingsActions.LoadPage('Organization')),
+      new SidenavOptions('Reports', 'assessment', new SettingsActions.LoadPage('Reports'))
     ]));
     this.settingsSubscription = this.store
       .select('settings')

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -39,7 +39,7 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   volunteers$: Observable<Volunteer[]>;
   volunteerTableOptions: ColumnOptions[];
 
-  constructor(private store: Store<State>) {
+  constructor(public store: Store<State>) {
     this.userFormTitle = 'Update user data.';
     this.organizationFormTitle = 'Update organization data.';
   }
@@ -71,36 +71,13 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
         false,
       )
     ));
-    this.store.dispatch(new AppActions.SetSidenavOptions([
-      new SidenavOptions(
-        'User',
-        'face',
-        new SettingsActions.LoadPage('user')
-      ),
-      new SidenavOptions(
-        'Organization',
-        'domain',
-        new SettingsActions.LoadPage('organization')
-      ),
-      new SidenavOptions(
-        'Volunteers',
-        'insert_emoticon',
-        new SettingsActions.LoadVolunteersPage(organizationId)
-      ),
-      new SidenavOptions(
-        'Reports',
-        'assessment',
-        new SettingsActions.LoadPage('Reports')
-      )
-    ]));
     // Setup subscriptions
     const settings$ = this.store.select('settings');
     this.settingsSubscription = settings$.subscribe(state => {
       this.sidenavSelection = state.sidenavSelection;
     });
     this.volunteers$ = settings$.map(state => state.volunteers);
-    this.appSubscription = this.store
-      .select('app')
+    this.appSubscription = this.store.select('app')
       .map(state => {
         return {
           user: state.user,
@@ -111,6 +88,30 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
       .subscribe(state => {
         this.initialUser = state.user;
         this.initialOrganization = state.organization;
+        if (state.organization) {
+          this.store.dispatch(new AppActions.SetSidenavOptions([
+            new SidenavOptions(
+              'User',
+              'face',
+              new SettingsActions.LoadPage('user')
+            ),
+            new SidenavOptions(
+              'Organization',
+              'domain',
+              new SettingsActions.LoadPage('organization')
+            ),
+            new SidenavOptions(
+              'Volunteers',
+              'insert_emoticon',
+              new SettingsActions.LoadVolunteersPage(state.organization.id)
+            ),
+            new SidenavOptions(
+              'Reports',
+              'assessment',
+              new SettingsActions.LoadPage('Reports')
+            )
+          ]));
+        }
       });
   }
 

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -115,15 +115,15 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Handles setUser events by setting validUser..
+   * Handles validUser events by setting validUser.
    * @param user - a valid user when valid, null when invalid
    */
-  onSetUser(user: User) {
+  onValidUser(user: User) {
     this.validUser = user;
   }
 
   /**
-   * Handles setOrganization events by setting validOrganization.
+   * Handles validOrganization events by setting validOrganization.
    * @param organization - a valid organization when valid, null when invalid
    */
   onValidOrganization(organization: Organization) {

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -134,8 +134,8 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   /**
    * Handles submission of user form by dispatching an UpdateUser action.
    */
-  onSubmitUser() {
-    this.store.dispatch(new SettingsActions.UpdateUser(this.validUser));
+  onSubmitUser(user: User) {
+    this.store.dispatch(new SettingsActions.UpdateUser(user));
   }
 
   /**

--- a/src/app/containers/settings-page/settings-page.component.ts
+++ b/src/app/containers/settings-page/settings-page.component.ts
@@ -149,7 +149,7 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
    * @param volunteer - the volunteer to be deleted
    */
   onDeleteVolunteer(volunteer: Volunteer) {
-    console.log('onDeleteVolunteer', volunteer);
+    this.store.dispatch(new SettingsActions.DeleteVolunteer(volunteer));
   }
 
   setReport($event) {

--- a/src/app/effects/settings.effects.spec.ts
+++ b/src/app/effects/settings.effects.spec.ts
@@ -6,6 +6,7 @@ import 'rxjs/add/observable/of';
 import { AuthService, MockAuthService } from '../services/auth.service';
 import { MockOrganizationService, OrganizationService } from '../services/organization.service';
 import { MockSnackBarService, SnackBarService } from '../services/snack-bar.service';
+import { MockVolunteerService, VolunteerService } from '../services/volunteer.service';
 import { SettingsEffects } from './settings.effects';
 
 describe('SettingsEffects', () => {
@@ -20,7 +21,8 @@ describe('SettingsEffects', () => {
         provideMockActions(() => actions),
         { provide: AuthService, useClass: MockAuthService },
         { provide: SnackBarService, useClass: MockSnackBarService },
-        { provide: OrganizationService, useClass: MockOrganizationService }
+        { provide: OrganizationService, useClass: MockOrganizationService },
+        { provide: VolunteerService, useClass: MockVolunteerService }
       ],
     });
     effects = TestBed.get(SettingsEffects);

--- a/src/app/effects/settings.effects.ts
+++ b/src/app/effects/settings.effects.ts
@@ -14,6 +14,7 @@ import * as SettingsActions from '../actions/settings.actions';
 import { AuthService } from '../services/auth.service';
 import { OrganizationService } from '../services/organization.service';
 import { SnackBarService } from '../services/snack-bar.service';
+import { VolunteerService } from '../services/volunteer.service';
 
 @Injectable()
 export class SettingsEffects {
@@ -23,8 +24,7 @@ export class SettingsEffects {
    * then dispatch action to app store and display success snack bar.
    */
   @Effect()
-  updateUser$: Observable<Action> = this.actions
-    .ofType(SettingsActions.UPDATE_USER)
+  updateUser$: Observable<Action> = this.actions.ofType(SettingsActions.UPDATE_USER)
     .map((action: SettingsActions.UpdateUser) => action.payload)
     .switchMap(user => this.authService.updateUser(user)
       .map(() => {
@@ -37,8 +37,7 @@ export class SettingsEffects {
    * then dispatch an action to app store and display success snack bar.
    */
   @Effect()
-  updateOrganization$: Observable<Action> = this.actions
-    .ofType(SettingsActions.UPDATE_ORGANIZATION)
+  updateOrganization$: Observable<Action> = this.actions.ofType(SettingsActions.UPDATE_ORGANIZATION)
     .map((action: SettingsActions.UpdateOrganization) => action.payload)
     .switchMap(organization => this.organizationService.update(organization)
       .map(() => {
@@ -46,9 +45,19 @@ export class SettingsEffects {
         return new AppActions.SetOrganization(organization)
       }));
 
+  /**
+   * Listen for the LoadVolunteers action, get the volunteers, then dispatch the success action.
+   */
+  @Effect()
+  loadData$: Observable<Action> = this.actions.ofType(SettingsActions.LOAD_VOLUNTEERS_PAGE)
+    .map((action: SettingsActions.LoadVolunteers) => action.payload)
+    .switchMap(organizationId => this.volunteerService.getByKey('organizationId', organizationId, true)
+    .map(volunteers => new SettingsActions.LoadVolunteersSuccess(volunteers)));
+
   constructor(private actions: Actions,
-              private snackBarService: SnackBarService,
               private authService: AuthService,
-              private organizationService: OrganizationService) {
+              private organizationService: OrganizationService,
+              private snackBarService: SnackBarService,
+              private volunteerService: VolunteerService) {
   }
 }

--- a/src/app/effects/settings.effects.ts
+++ b/src/app/effects/settings.effects.ts
@@ -46,13 +46,13 @@ export class SettingsEffects {
       }));
 
   /**
-   * Listen for the LoadVolunteers action, get the volunteers, then dispatch the success action.
+   * Listen for the LoadVolunteersPage action, get the volunteers, then dispatch the success action.
    */
   @Effect()
   loadData$: Observable<Action> = this.actions.ofType(SettingsActions.LOAD_VOLUNTEERS_PAGE)
-    .map((action: SettingsActions.LoadVolunteers) => action.payload)
+    .map((action: SettingsActions.LoadVolunteersPage) => action.payload)
     .switchMap(organizationId => this.volunteerService.getByKey('organizationId', organizationId, true)
-    .map(volunteers => new SettingsActions.LoadVolunteersSuccess(volunteers)));
+    .map(volunteers => new SettingsActions.LoadVolunteersPageSuccess(volunteers)));
 
   constructor(private actions: Actions,
               private authService: AuthService,

--- a/src/app/effects/settings.effects.ts
+++ b/src/app/effects/settings.effects.ts
@@ -20,6 +20,24 @@ import { VolunteerService } from '../services/volunteer.service';
 export class SettingsEffects {
 
   /**
+   * Listen for the LoadVolunteersPage action, get the volunteers, then dispatch the success action.
+   */
+  @Effect()
+  deleteVolunteer$: Observable<Action> = this.actions.ofType(SettingsActions.DELETE_VOLUNTEER)
+    .map((action: SettingsActions.DeleteVolunteer) => action.payload)
+    .switchMap(volunteer => this.volunteerService.delete(volunteer)
+      .map(() => new SettingsActions.DeleteVolunteerSuccess(volunteer)));
+
+  /**
+   * Listen for the LoadVolunteersPage action, get the volunteers, then dispatch the success action.
+   */
+  @Effect()
+  loadData$: Observable<Action> = this.actions.ofType(SettingsActions.LOAD_VOLUNTEERS_PAGE)
+    .map((action: SettingsActions.LoadVolunteersPage) => action.payload)
+    .switchMap(organizationId => this.volunteerService.getByKey('organizationId', organizationId, true)
+      .map(volunteers => new SettingsActions.LoadVolunteersPageSuccess(volunteers)));
+
+  /**
    * Listen for the UpdateUser action, update user,
    * then dispatch action to app store and display success snack bar.
    */
@@ -44,15 +62,6 @@ export class SettingsEffects {
         this.snackBarService.updateOrganizationSuccess();
         return new AppActions.SetOrganization(organization)
       }));
-
-  /**
-   * Listen for the LoadVolunteersPage action, get the volunteers, then dispatch the success action.
-   */
-  @Effect()
-  loadData$: Observable<Action> = this.actions.ofType(SettingsActions.LOAD_VOLUNTEERS_PAGE)
-    .map((action: SettingsActions.LoadVolunteersPage) => action.payload)
-    .switchMap(organizationId => this.volunteerService.getByKey('organizationId', organizationId, true)
-    .map(volunteers => new SettingsActions.LoadVolunteersPageSuccess(volunteers)));
 
   constructor(private actions: Actions,
               private authService: AuthService,

--- a/src/app/effects/settings.effects.ts
+++ b/src/app/effects/settings.effects.ts
@@ -82,6 +82,7 @@ export class SettingsEffects {
               private authService: AuthService,
               private organizationService: OrganizationService,
               private snackBarService: SnackBarService,
+              private visitService: VisitService,
               private volunteerService: VolunteerService) {
   }
 }

--- a/src/app/reducers/settings.reducer.spec.ts
+++ b/src/app/reducers/settings.reducer.spec.ts
@@ -3,12 +3,12 @@ import * as fromSettings from './settings.reducer'
 
 describe('settingsReducer', () => {
 
-  describe('SET_SIDENAV_SELECTION', () => {
+  describe('LOAD_PAGE', () => {
 
     it('loads sidenav selection', () => {
       const state = fromSettings.reducer(
         fromSettings.initialState,
-        new SettingsActions.SetSidenavSelection('Organization')
+        new SettingsActions.LoadPage('Organization')
       );
       expect(state.sidenavSelection).toEqual('Organization');
     });

--- a/src/app/reducers/settings.reducer.ts
+++ b/src/app/reducers/settings.reducer.ts
@@ -9,7 +9,7 @@ export interface State {
 }
 
 export const initialState: State = {
-  sidenavSelection: 'User',
+  sidenavSelection: 'user',
   visits: null,
   volunteers: null
 };

--- a/src/app/reducers/settings.reducer.ts
+++ b/src/app/reducers/settings.reducer.ts
@@ -24,6 +24,7 @@ export function reducer(state = initialState, action: Action): State {
 
     case SettingsActions.LOAD_VOLUNTEERS_PAGE_SUCCESS: {
       return Object.assign({}, state, {
+        sidenavSelection: 'volunteers',
         volunteers: action.payload
       });
     }

--- a/src/app/reducers/settings.reducer.ts
+++ b/src/app/reducers/settings.reducer.ts
@@ -1,11 +1,14 @@
 import * as SettingsActions from '../actions/settings.actions';
+import { Volunteer } from '../models/volunteer';
 
 export interface State {
   sidenavSelection: string;
+  volunteers: Volunteer[];
 }
 
 export const initialState: State = {
   sidenavSelection: 'User',
+  volunteers: null
 };
 
 export type Action = SettingsActions.All;
@@ -13,9 +16,15 @@ export type Action = SettingsActions.All;
 export function reducer(state = initialState, action: Action): State {
   switch (action.type) {
 
-    case SettingsActions.SET_SIDENAV_SELECTION: {
+    case SettingsActions.LOAD_PAGE: {
       return Object.assign({}, state, {
         sidenavSelection: action.payload
+      });
+    }
+
+    case SettingsActions.LOAD_VOLUNTEERS_PAGE_SUCCESS: {
+      return Object.assign({}, state, {
+        volunteers: action.payload
       });
     }
 

--- a/src/app/reducers/settings.reducer.ts
+++ b/src/app/reducers/settings.reducer.ts
@@ -16,6 +16,12 @@ export type Action = SettingsActions.All;
 export function reducer(state = initialState, action: Action): State {
   switch (action.type) {
 
+    case SettingsActions.DELETE_VOLUNTEER_SUCCESS: {
+      return Object.assign({}, state, {
+        volunteers: state.volunteers.filter(volunteer => volunteer !== action.payload)
+      })
+    }
+
     case SettingsActions.LOAD_PAGE: {
       return Object.assign({}, state, {
         sidenavSelection: action.payload


### PR DESCRIPTION
## Resolves #207 

Add volunteers data table page to settings to allow deleting of volunteers.

## Testing

- [x] Navigate to settings page.
- [x] Select the **Volunteers** sidenav option.
- [x] Delete some volunteers and verify the table is updated.
- [x] Navigate to the check-in page.
- [x] Verify the volunteers do not appear as autocomplete options.