### PR TITLE
Fix page overflow

### DIFF
--- a/src/app/components/sidenav/sidenav.component.html
+++ b/src/app/components/sidenav/sidenav.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container class="container">
+<mat-sidenav-container class="container" [autosize]="true">
   <mat-sidenav [mode]="mode">
     <mat-nav-list>
       <mat-list-item

--- a/src/app/components/sidenav/sidenav.component.scss
+++ b/src/app/components/sidenav/sidenav.component.scss
@@ -1,3 +1,4 @@
+@import '~@angular/material/_theming.scss';
 @import '~styles.scss';
 
 .container {
@@ -8,8 +9,13 @@ mat-sidenav {
   box-shadow: 3px 0 6px rgba(0,0,0,.24);
 }
 
+// Allows for vertical scrolling when page content overflows below footer
 mat-sidenav-content {
   max-height: calc(100vh - #{$mat-toolbars-height-desktop});
+
+  @media ($mat-xsmall) {
+    max-height: calc(100vh - #{$mat-toolbar-height-mobile});
+  }
 }
 
 .material-icons {

--- a/src/app/components/sidenav/sidenav.component.scss
+++ b/src/app/components/sidenav/sidenav.component.scss
@@ -1,9 +1,15 @@
+@import '~styles.scss';
+
 .container {
   height: 100%;
 }
 
 mat-sidenav {
   box-shadow: 3px 0 6px rgba(0,0,0,.24);
+}
+
+mat-sidenav-content {
+  max-height: calc(100vh - #{$mat-toolbars-height-desktop});
 }
 
 .material-icons {

--- a/src/app/containers/data-display/data-display.component.html
+++ b/src/app/containers/data-display/data-display.component.html
@@ -5,8 +5,7 @@
   <mat-tab label="Visit History">
     <app-data-table
       [columnOptions]="visitTableColumnOptions"
-      [data$]="visits$"
-      [showDelete]="true">
+      [data$]="visits$">
     </app-data-table>
   </mat-tab>
 </mat-tab-group>


### PR DESCRIPTION
## Resolves #206 

## Changes
- Allow scrolling to page content that overflows below footer.
- Allow for sidenav container to auto-resize while open. [See material2 fix.](https://github.com/angular/material2/pull/8488)
- Remove delete buttons in visit history table.

## Testing steps
- [x] Navigate to settings page.
- [x] Verify that you can scroll down to view the entire user form.
- [x] Select the Volunteers sidenav option.
- [x] Verify that the table does not go under the sidenav.
- [x] Verify that the above behave properly with xs screens.
