### PR TITLE
Replace require with ES6 import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 script:
   - yarn run test:ci
   - yarn run lint
+  - yarn run build:dev
 
 before_deploy:
   - if [[ "$TRAVIS_BRANCH" = "master" ]]; then yarn run build:dev; fi

--- a/src/app/containers/check-in/check-in.component.ts
+++ b/src/app/containers/check-in/check-in.component.ts
@@ -2,10 +2,10 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatTabGroup } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
+import * as _ from 'lodash';
+import 'rxjs/add/operator/distinctUntilChanged';
 import { Subscription } from 'rxjs/Subscription';
 
-import _ = require('lodash');
-import 'rxjs/add/operator/distinctUntilChanged';
 import * as AppActions from '../../actions/app.actions';
 import * as CheckInActions from '../../actions/check-in.actions';
 import { HeaderOptions } from '../../models/header-options';


### PR DESCRIPTION
## Resolves #223

## Changes
- Replace `require` with ES6 import.

## Testing steps
- [ ] Run command `yarn run build:dev`.
- [ ] Verify the command exits successfully and the build outputs to `/dist`.