### PR TITLE
Display site data

### DIFF
--- a/src/app/public/containers/view-activity-page/view-activity-page.component.html
+++ b/src/app/public/containers/view-activity-page/view-activity-page.component.html
@@ -1,6 +1,6 @@
 <div class="container" *ngIf="organization">
   <app-data-display
-    [visits$]="visits$">
+    [visits$]="visits$" [sites$]="sites$">
   </app-data-display>
 </div>
 <div class="container-center loose" *ngIf="showNotFound">

--- a/src/app/public/containers/view-activity-page/view-activity-page.component.spec.ts
+++ b/src/app/public/containers/view-activity-page/view-activity-page.component.spec.ts
@@ -12,7 +12,7 @@ describe('ViewActivityPageComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         ViewActivityPageComponent,
-        MockComponent({ selector: 'app-data-display', inputs: ['visits$'] }),
+        MockComponent({ selector: 'app-data-display', inputs: ['visits$', 'sites$'] }),
       ],
       imports: [
         ...mockStoreModules,

--- a/src/app/public/containers/view-activity-page/view-activity-page.component.ts
+++ b/src/app/public/containers/view-activity-page/view-activity-page.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { select, Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 import * as LayoutActions from '../../../core/actions/layout.actions';
 import { AppState } from '../../../core/reducers';
+import { selectModelSites } from '../../../core/selectors/model.selectors';
 import { ErrorService } from '../../../core/services/error.service';
 import { OrganizationService } from '../../../core/services/organization.service';
 import { VisitService } from '../../../core/services/visit.service';
-import { HeaderOptions, Organization, Visit } from '../../../shared/models';
+import { HeaderOptions, Organization, Site, Visit } from '../../../shared/models';
 
 @Component({
   selector: 'app-view-activity-page',
@@ -16,6 +17,7 @@ import { HeaderOptions, Organization, Visit } from '../../../shared/models';
 export class ViewActivityPageComponent implements OnInit, OnDestroy {
   organization: Organization;
   visits$: Observable<Visit[]>;
+  sites$: Observable<Site[]>;
   showNotFound: boolean;
   subscription: Subscription;
 
@@ -27,6 +29,7 @@ export class ViewActivityPageComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.sites$ = this.store$.pipe(select(selectModelSites));
     this.subscription = this.organizationService.getByKey('name', this.getOrganizationNameByUrl(), true)
       .subscribe(
         (organizations: Organization[]) => {

--- a/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.html
+++ b/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container" style="display: block" *ngIf="data.length > 0">
   <canvas class="graph"
           baseChart
           [datasets]="data"

--- a/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.html
+++ b/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.html
@@ -1,4 +1,4 @@
-<div class="container" style="display: block" *ngIf="data.length > 0">
+<div class="container" style="display: block" *ngIf="!isVisitsEmpty(visits)">
   <canvas class="graph"
           baseChart
           [datasets]="data"

--- a/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.spec.ts
+++ b/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.spec.ts
@@ -1,12 +1,16 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChartsModule } from 'ng2-charts';
+import { createMockSites } from '../../../../mocks/objects/site.mock';
 import { createMockVisits } from '../../../../mocks/objects/visit.mock';
+import { Site, Visit } from '../../models';
 import { DailyHoursChartComponent } from './daily-hours-chart.component';
 
 describe('DailyHoursChartComponent', () => {
   let component: DailyHoursChartComponent;
   let fixture: ComponentFixture<DailyHoursChartComponent>;
   let testLabels: string[];
+  let sites: Site[];
+  let visits: Visit[];
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -25,6 +29,8 @@ describe('DailyHoursChartComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     testLabels = ['Wed Jun 28', 'Thu Jun 29', 'Fri Jun 30', 'Sat Jul 1', 'Sun Jul 2'];
+    sites = createMockSites();
+    visits = createMockVisits();
   });
 
   it('should be created', () => {
@@ -39,11 +45,14 @@ describe('DailyHoursChartComponent', () => {
       expect(label).toEqual(testLabels[index]));
   });
 
-  it('should set up the line chart data', () => {
-    const lineChartData = component.setupLineChartData(createMockVisits(), testLabels)[0];
+  it('should set up the line chart data for a data set', () => {
+    const mapOfSites = new Map(
+      sites.map<[string, string]>((site: Site) => [site.id, site.label]),
+    );
+    const lineChartData = component.setupLineChartDataForDataSet(createMockVisits(), testLabels, mapOfSites);
     expect(lineChartData.data.length).toEqual(5);
     expect(lineChartData.data[0]).toEqual('0.000');
     expect(lineChartData.data[1]).toEqual('10.000');
-    expect(lineChartData.label).toEqual('Hours');
+    expect(lineChartData.label).toEqual('Jefferson Parish Animal Shelter Hours');
   });
 });

--- a/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.ts
+++ b/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.ts
@@ -9,6 +9,7 @@ import { Visit } from '../../models';
 })
 export class DailyHoursChartComponent implements OnChanges {
   @Input() visits: Visit[];
+  @Input() sites: Visit[];
   data: LineChartData[];
   labels: string[];
   type = 'line';
@@ -27,7 +28,7 @@ export class DailyHoursChartComponent implements OnChanges {
     if (changes['visits']) {
       this.data = [];
       this.labels = this.setupLineChartLabels();
-      this.getEachDataSetBySite(changes['visits'].currentValue).forEach((dataSet: Visit[]) => {
+      this.getDataSetsBySite(changes['visits'].currentValue).forEach((dataSet: Visit[]) => {
         this.data.push(this.setupLineChartData(dataSet, this.labels));
       });
     }
@@ -41,7 +42,7 @@ export class DailyHoursChartComponent implements OnChanges {
    * @param {Visit[]} visits
    * @returns {Visit[][]}
    */
-  getEachDataSetBySite(visits: Visit[]): Visit[][] {
+  getDataSetsBySite(visits: Visit[]): Visit[][] {
     const mapOfVisits = new Map<string, Visit[]>();
     if (visits) {
       visits.forEach((visit: Visit) => {

--- a/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.ts
+++ b/src/app/shared/components/daily-hours-chart/daily-hours-chart.component.ts
@@ -24,12 +24,16 @@ export class DailyHoursChartComponent implements OnChanges {
     },
   };
 
+  isVisitsEmpty(visits: Visit[]): boolean {
+    return visits && visits.length > 0 ? false : true;
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['visits']) {
       this.data = [];
-      const mapOfSites = new Map(
+      const mapOfSites = this.sites ? new Map(
         this.sites.map<[string, string]>((site: Site) => [site.id, site.label]),
-      );
+      ) : new Map();
       this.labels = this.setupLineChartLabels();
       this.getDataSetsBySite(changes['visits'].currentValue).forEach((dataSet: Visit[]) => {
         this.data.push(this.setupLineChartDataForDataSet(dataSet, this.labels, mapOfSites));
@@ -49,6 +53,7 @@ export class DailyHoursChartComponent implements OnChanges {
     const mapOfVisits = new Map<string, Visit[]>();
     if (visits) {
       visits.forEach((visit: Visit) => {
+        visit.siteId = visit.siteId !== null ? visit.siteId : 'noSite';
         if (mapOfVisits.get(visit.siteId)) {
           const visits = mapOfVisits.get(visit.siteId);
           visits.push(visit);
@@ -114,7 +119,7 @@ export class DailyHoursChartComponent implements OnChanges {
           Array(labels.length).fill(0),
         )
           .map(value => value.toFixed(3)),
-        label: mapOfSites.get(visits[0].siteId) ? mapOfSites.get(visits[0].siteId) : 'No site',
+        label: visits[0].siteId === 'noSite' ? 'No site' + ' Hours' : mapOfSites.get(visits[0].siteId) + ' Hours',
       }
       : { data: [], label: '' };
   }

--- a/src/app/shared/components/data-display/data-display.component.html
+++ b/src/app/shared/components/data-display/data-display.component.html
@@ -2,7 +2,7 @@
 <ng-template #loaded>
   <mat-tab-group id="data-display-tab-group" mat-stretch-tabs #tabGroup>
     <mat-tab label="Daily Hours">
-      <app-daily-hours-chart [visits]="visits$ | async"></app-daily-hours-chart>
+      <app-daily-hours-chart [visits]="visits$ | async" [sites]="sites$ | async"></app-daily-hours-chart>
     </mat-tab>
     <mat-tab label="Visit History">
       <app-data-table

--- a/src/app/shared/components/data-display/data-display.component.spec.ts
+++ b/src/app/shared/components/data-display/data-display.component.spec.ts
@@ -17,7 +17,7 @@ describe('DataDisplayComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         DataDisplayComponent,
-        MockComponent({ selector: 'app-daily-hours-chart', inputs: ['visits'] }),
+        MockComponent({ selector: 'app-daily-hours-chart', inputs: ['visits', 'sites'] }),
         MockComponent({
           selector: 'app-data-table',
           inputs: ['columnOptions', 'data$', 'showDelete', 'getRowColor'],

--- a/src/app/shared/components/data-display/data-display.component.ts
+++ b/src/app/shared/components/data-display/data-display.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { formatDate, formatDuration, formatTime } from '../../helpers';
-import { ColumnOptions, Visit } from '../../models';
+import { ColumnOptions, Site, Visit } from '../../models';
 
 @Component({
   selector: 'app-data-display',
@@ -10,6 +10,7 @@ import { ColumnOptions, Visit } from '../../models';
 })
 export class DataDisplayComponent implements OnInit {
   @Input() visits$: Observable<Visit[]>;
+  @Input() sites$: Observable<Site[]>;
   visitTableColumnOptions: ColumnOptions[] = [
     {
       columnDef: 'date',

--- a/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.html
+++ b/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.html
@@ -1,3 +1,3 @@
 <div class="container">
-  <app-data-display [visits$]="visits$"></app-data-display>
+  <app-data-display [visits$]="visits$" [sites$]="sites$"></app-data-display>
 </div>

--- a/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.spec.ts
+++ b/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.spec.ts
@@ -13,7 +13,7 @@ describe('OrganizationDashboardPageComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         OrganizationDashboardPageComponent,
-        MockComponent({ selector: 'app-data-display', inputs: ['visits$'] }),
+        MockComponent({ selector: 'app-data-display', inputs: ['visits$', 'sites$'] }),
       ],
       imports: [
         RouterTestingModule,

--- a/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.ts
+++ b/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.ts
@@ -3,11 +3,11 @@ import { select, Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 import * as LayoutActions from '../../../core/actions/layout.actions';
 import { AppState } from '../../../core/reducers';
-import { selectModelVisits } from '../../../core/selectors/model.selectors';
-import { Visit } from '../../../shared/models';
+import { selectModelSites } from '../../../core/selectors/model.selectors';
+import { Site, Visit } from '../../../shared/models';
 import {
   selectOrganizationDashboardHeaderOptions,
-  selectOrganizationDashboardSidenavOptions,
+  selectOrganizationDashboardSidenavOptions, selectVolunteerDashboardVisits,
 } from '../../selectors/organization-dashboard.selectors';
 
 @Component({
@@ -19,11 +19,13 @@ export class OrganizationDashboardPageComponent implements OnInit, OnDestroy {
   private headerSubscription: Subscription;
   private sidenavSubscription: Subscription;
   visits$: Observable<Visit[]>;
+  sites$: Observable<Site[]>;
 
   constructor(private store$: Store<AppState>) {}
 
   ngOnInit(): void {
-    this.visits$ = this.store$.pipe(select(selectModelVisits));
+    this.visits$ = this.store$.pipe(select(selectVolunteerDashboardVisits));
+    this.sites$ = this.store$.pipe(select(selectModelSites));
     this.headerSubscription = this.store$.pipe(select(selectOrganizationDashboardHeaderOptions))
       .subscribe((headerOptions) => {
         this.store$.dispatch(new LayoutActions.SetHeaderOptions(headerOptions));

--- a/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.ts
+++ b/src/app/volunteers/containers/organization-dashboard-page/organization-dashboard-page.component.ts
@@ -7,7 +7,7 @@ import { selectModelSites } from '../../../core/selectors/model.selectors';
 import { Site, Visit } from '../../../shared/models';
 import {
   selectOrganizationDashboardHeaderOptions,
-  selectOrganizationDashboardSidenavOptions, selectVolunteerDashboardVisits,
+  selectOrganizationDashboardSidenavOptions, selectOrganizationDashboardVisits,
 } from '../../selectors/organization-dashboard.selectors';
 
 @Component({
@@ -24,7 +24,7 @@ export class OrganizationDashboardPageComponent implements OnInit, OnDestroy {
   constructor(private store$: Store<AppState>) {}
 
   ngOnInit(): void {
-    this.visits$ = this.store$.pipe(select(selectVolunteerDashboardVisits));
+    this.visits$ = this.store$.pipe(select(selectOrganizationDashboardVisits));
     this.sites$ = this.store$.pipe(select(selectModelSites));
     this.headerSubscription = this.store$.pipe(select(selectOrganizationDashboardHeaderOptions))
       .subscribe((headerOptions) => {

--- a/src/app/volunteers/selectors/organization-dashboard.selectors.ts
+++ b/src/app/volunteers/selectors/organization-dashboard.selectors.ts
@@ -1,8 +1,25 @@
 import { createSelector } from '@ngrx/store';
 import { selectSessionOrganization } from '../../auth/selectors/session.selectors';
 import * as RouterActions from '../../core/actions/router.actions';
-import { selectModelSites } from '../../core/selectors/model.selectors';
-import { HeaderOptions, Organization, SidenavOptions, Site } from '../../shared/models';
+import { selectModelSites, selectModelVisits } from '../../core/selectors/model.selectors';
+import { HeaderOptions, Organization, SidenavOptions, Site, Visit } from '../../shared/models';
+
+/**
+ * Filter out visits that do not equal the selected site.
+ *
+ * @type {MemoizedSelector<object, Visit[]>}
+ */
+export const selectVolunteerDashboardVisits = createSelector(
+  selectModelVisits,
+  (visits: Visit[]): Visit[] => {
+    return visits ? visits.reduce((filteredVisits, visit) => {
+      if (visit.siteId !== 'getSetSiteIdHere') {
+        filteredVisits.push(visit);
+      }
+      return filteredVisits;
+    },                            []) : [];
+  },
+);
 
 export const selectOrganizationDashboardHeaderOptions = createSelector(
   selectSessionOrganization,

--- a/src/app/volunteers/selectors/organization-dashboard.selectors.ts
+++ b/src/app/volunteers/selectors/organization-dashboard.selectors.ts
@@ -9,7 +9,7 @@ import { HeaderOptions, Organization, SidenavOptions, Site, Visit } from '../../
  *
  * @type {MemoizedSelector<object, Visit[]>}
  */
-export const selectVolunteerDashboardVisits = createSelector(
+export const selectOrganizationDashboardVisits = createSelector(
   selectModelVisits,
   (visits: Visit[]): Visit[] => {
     return visits ? visits.reduce((filteredVisits, visit) => {

--- a/src/mocks/objects/site.mock.ts
+++ b/src/mocks/objects/site.mock.ts
@@ -3,14 +3,14 @@ import { Site } from '../../app/shared/models';
 
 export const mockSites: Site[] = [
   {
-    id: '59a7055733bfe28af47cff40',
+    id: '59bc1e7ad92a6ac6f6252bfa',
     organizationId: '59a7055733bfe28af47cff40',
     label: 'Jefferson SPCA Animal Shelter',
     description: 'A Place',
     address: '1 Humane Way, New Orleans, LA 70123',
   },
   {
-    id: '59a7055733bfe28af47cff41',
+    id: '59bc1e7ad92a6ac6f6252bfa',
     organizationId: '59a7055733bfe28af47cff40',
     label: 'Jefferson Parish Animal Shelter',
     description: 'once upon a time',


### PR DESCRIPTION
# Changes
Display visits according to sites on data display.

## Data Flow
1. Pass visits you want displayed into data table and all sites for a team
2. Data table will sort and display visits accordingly  

The team dashboard filters out visits that do not match the selected site. 